### PR TITLE
Improve the guard preventing a survey from showing when another is already displayed

### DIFF
--- a/delighted/Classes/DelightedPageViewController.swift
+++ b/delighted/Classes/DelightedPageViewController.swift
@@ -145,11 +145,13 @@ class DelightedPageViewController: UIPageViewController {
             }) { (_) in
                 // Releases the window
                 Delighted.window = nil
+                Delighted.surveying = false
                 completion?()
             }
         } else {
             // Releases the window
             Delighted.window = nil
+            Delighted.surveying = false
             completion?()
         }
     }


### PR DESCRIPTION
A call to `Delighted.survey()` checks that a survey isn't already showing before continuing. The mechanism supporting this relies on checking whether the window representing the survey is defined. A window, however, won't be defined until after the eligibility check completes (which makes a network call). This leaves a gap where a second call to `Delighted.survey()` gets past the visibility check and proceeds to show the survey.
