### PR TITLE
Expose Person initializer to Objective-C

### DIFF
--- a/delighted/Classes/Person.swift
+++ b/delighted/Classes/Person.swift
@@ -5,7 +5,7 @@ import Foundation
     let email: String?
     let phoneNumber: String?
     
-    public init(name: String? = nil, email: String? = nil, phoneNumber: String? = nil) {
+    @objc public init(name: String? = nil, email: String? = nil, phoneNumber: String? = nil) {
         self.name = name
         self.email = email
         self.phoneNumber = phoneNumber


### PR DESCRIPTION
In order to pass a Person object to the Delighted survey API in Obj-C, the initializer needs to be exposed.