### PR TITLE
update resource to resource_bundles in podspec

### DIFF
--- a/Delighted.podspec
+++ b/Delighted.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.module_name           = "Delighted"
   spec.swift_version         = "5.0"
   spec.ios.source_files      = "delighted/Classes/*.swift"
-  spec.resources             = "delighted/Assets/*.xcassets"
+  spec.resource_bundles          = { 'Delighted' => ['delighted/Assets/*.xcassets'] }
 
   spec.dependency "Starscream", "~> 3.1.1" # Support for Swift 5
 end

--- a/delighted/Classes/Images.swift
+++ b/delighted/Classes/Images.swift
@@ -19,7 +19,9 @@ enum Images: String {
     case thumbsDown = "thumbs_down"
     
     var image: UIImage? {
-        let bundle = Bundle(for: ImagesClassForBundle.self)
+        let mainbundle = Bundle(for: ImagesClassForBundle.self)
+        //Name of Bundle assets can be found in Delighted.podspec
+        let bundle = Bundle(path: mainbundle.bundlePath + "/Delighted.bundle")
         let image = UIImage(named: rawValue, in: bundle, compatibleWith: nil)
         return image
     }


### PR DESCRIPTION
Hi,

following the installation through cocoapods,I found a error when build the project, has a duplicate Assets.car. This happening because Delighted SDK create one Assets and our app create another one.

You should be use the new cocoapods resource_bundle to create a bundle for external dependence and not conflict with other resources.

I created this Pull Request to fix or show the way to do this.

Thanks and best regard