### PR TITLE
Fix deserialization error for some survey configurations

### DIFF
--- a/Example/Tests/ClientEligibilityTests.swift
+++ b/Example/Tests/ClientEligibilityTests.swift
@@ -430,4 +430,38 @@ class ClientEligibilityTests: XCTestCase {
         
         waitForExpectations(timeout: 0.3, handler: nil)
     }
+
+    func testFailWithRecurringSurveyDisabled() {
+        // Set up a person that was previously surveyed
+        let dateAnHourAgo = Date().addingTimeInterval(-61)
+        let eligibility = ClientEligibility(preSurveySession: preSurveySession)
+        let defaults = eligibility.getDefaults(with: configuration)
+        eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
+        eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
+
+        let configuration = EligibilityConfiguration(
+            surveyContextId: "",
+            enabled: true,
+            minSurveyInterval: 60,
+            sampleFactor: 1,
+            recurringSurveyPeriod: nil,
+            initialSurveyDelay: 0,
+            forceDisplay: false,
+            planLimitExhausted: false
+        )
+
+        let failExpectation = expectation(description: "Fail")
+        eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
+
+        }) { (failedReason) in
+            if case ClientEligibility.FailedReason.recurringSurveyDisabled = failedReason {
+                // Success
+            } else {
+                XCTFail("wrong error")
+            }
+            failExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.3, handler: nil)
+    }
 }

--- a/delighted/Classes/EligibilityConfiguration.swift
+++ b/delighted/Classes/EligibilityConfiguration.swift
@@ -5,8 +5,8 @@ struct EligibilityConfiguration {
     let enabled: Bool
     let minSurveyInterval: Int
     let sampleFactor: Float
-    var recurringSurveyPeriod: Int
-    var initialSurveyDelay: Int
+    var recurringSurveyPeriod: Int?
+    var initialSurveyDelay: Int?
     let forceDisplay: Bool
     let planLimitExhausted: Bool
 }


### PR DESCRIPTION
The SDK may fail to deserialize the response from the server when requesting the survey configuration. When this happens the error message, "Could not decode eligibility configuration request", appears in the console and the survey will not be shown.

The client-side eligibility check performed by the SDK uses the survey configuration which may have null values for the `initialSurveyDelay` and `recurringPeriod` fields. Since the SDK expects these to always be non-nil, the response fails to be decoded leading to the error. 

The SDK should really treat these fields as optional since they don't apply in some configurations. A bonus to changing this is that it allows for a more specific eligibility error message when the SDK is set up as a one-time survey.