### PR TITLE
Update to Starscream 4.0.4 + fixed code styling

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,31 @@
+disabled_rules:
+  - line_length
+  - notification_center_detachment
+  - void_return
+  - function_body_length
+  - identifier_name
+  - file_length
+  - function_parameter_count
+  - private_over_fileprivate
+  - type_body_length
+  - type_name
+  - large_tuple
+  - empty_parentheses_with_trailing_closure
+  - trailing_comma
+  - for_where
+  - cyclomatic_complexity
+  - todo
+  - control_statement
+  - block_based_kvo
+  - comment_spacing
+  - nesting
+force_cast: warning # implicitly
+force_try:
+  severity: warning # explicitly
+vertical_whitespace:
+  severity: error
+included:
+  - delighted/Classes/
+excluded:
+  - _Pods.xcodeproj
+  - Example

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" == 3.1.1
+github "daltoniam/Starscream" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" "3.1.1"
+github "daltoniam/Starscream" "4.0.4"

--- a/Delighted.podspec
+++ b/Delighted.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |spec|
   spec.ios.source_files      = "delighted/Classes/*.swift"
   spec.resources             = "delighted/Assets/*.xcassets"
 
-  spec.dependency "Starscream", "~> 3.1.1" # Support for Swift 5
+  spec.dependency "Starscream", "~> 4.0.4" # Support for Swift 5
 end

--- a/Delighted.podspec
+++ b/Delighted.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |spec|
   spec.ios.source_files      = "delighted/Classes/*.swift"
   spec.resources             = "delighted/Assets/*.xcassets"
 
-  spec.dependency "Starscream", "~> 4.0.4" # Support for Swift 5
+  spec.dependency "Starscream", "~> 4.0" # Support for Swift 5
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Delighted (1.0.2):
-    - Starscream (~> 3.1.1)
-  - Starscream (3.1.1)
+  - Delighted (1.0.3):
+    - Starscream (~> 4.0.4)
+  - Starscream (4.0.4)
 
 DEPENDENCIES:
   - Delighted (from `../`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Delighted: 18175b766c2e029d8d42ad2de4fb36a6cdadf5c7
-  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
+  Delighted: d837987f121f0fa15eaba864bf9136a6994814c8
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
 
 PODFILE CHECKSUM: 0f230a2ccba2267820517754de572226c7d8e5cf
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Delighted (1.0.3):
-    - Starscream (~> 4.0.4)
+    - Starscream (~> 4.0)
   - Starscream (4.0.4)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Delighted: d837987f121f0fa15eaba864bf9136a6994814c8
+  Delighted: 47af1841a49739325160d72452e2ec149e194e7d
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
 
 PODFILE CHECKSUM: 0f230a2ccba2267820517754de572226c7d8e5cf

--- a/Example/Tests/ClientEligibilityTests.swift
+++ b/Example/Tests/ClientEligibilityTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import Delighted
 
 class ClientEligibilityTests: XCTestCase {
-    
+
     var preSurveySession = PreSurveySession(delightedID: "", baseURL: nil, cdnURL: nil, callback: nil)
-    
+
     var configuration = EligibilityConfiguration(
         surveyContextId: "",
         enabled: false,
@@ -15,7 +15,7 @@ class ClientEligibilityTests: XCTestCase {
         forceDisplay: false,
         planLimitExhausted: false
     )
-    
+
     func testOverrides() {
         XCTAssertEqual(configuration.enabled, false)
         XCTAssertEqual(configuration.minSurveyInterval, 0)
@@ -24,7 +24,7 @@ class ClientEligibilityTests: XCTestCase {
         XCTAssertEqual(configuration.initialSurveyDelay, 1)
         XCTAssertEqual(configuration.forceDisplay, false)
         XCTAssertEqual(configuration.planLimitExhausted, false)
-        
+
         let overrides = EligibilityOverrides(
             testMode: false,
             createdAt: nil,
@@ -32,7 +32,7 @@ class ClientEligibilityTests: XCTestCase {
             recurringPeriod: 200
         )
         configuration.apply(overrides: overrides)
-        
+
         XCTAssertEqual(configuration.enabled, false)
         XCTAssertEqual(configuration.minSurveyInterval, 0)
         XCTAssertEqual(configuration.sampleFactor, 1)
@@ -41,26 +41,26 @@ class ClientEligibilityTests: XCTestCase {
         XCTAssertEqual(configuration.forceDisplay, false)
         XCTAssertEqual(configuration.planLimitExhausted, false)
     }
-    
+
     func testPassOnTest() {
         let passExpectation = expectation(description: "Pass")
-        
+
         let overrides = EligibilityOverrides(testMode: true)
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
-        
+
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
-        
+
         eligibility.check(with: overrides, whenEligible: {
 
             passExpectation.fulfill()
-        }) { (failedStep) in
+        }) { (_) in
             XCTFail("Check should have passed right away")
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnEnabledFalse() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
@@ -76,10 +76,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.enabled = failedReason {
                 // Success
@@ -88,15 +88,15 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnPlanExhaustedTrue() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -107,10 +107,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: true
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.exhausted = failedReason {
                 // Success
@@ -119,15 +119,15 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testPassOnForceDisplayTrue() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -138,23 +138,23 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: true,
             planLimitExhausted: false
         )
-        
+
         let passExpectation = expectation(description: "Pass")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
             passExpectation.fulfill()
-        }) { (failedStep) in
-            
+        }) { (_) in
+
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testPassOnNotPreviousSurveyedWithNoInitialDelay() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
         eligibility.setLastSurveyedDate(defaults: defaults, date: nil)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -165,23 +165,23 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let passExpectation = expectation(description: "Pass")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
             passExpectation.fulfill()
-        }) { (failedStep) in
-            
+        }) { (_) in
+
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnNotPreviousSurveyedWithInitialDelay() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
         eligibility.setLastSurveyedDate(defaults: defaults, date: nil)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -192,10 +192,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.initialDelay = failedReason {
                 // Success
@@ -204,16 +204,16 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnNotPreviousSurveyedButOverriddenCreatedAt() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
         eligibility.setLastSurveyedDate(defaults: defaults, date: nil)
-        
+
         var configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -224,14 +224,14 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let createdAt = Date().addingTimeInterval(-59)
         let overrides = EligibilityOverrides(createdAt: createdAt)
         configuration.apply(overrides: overrides)
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(overrides: overrides, eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.initialDelay = failedReason {
                 // Success
@@ -240,16 +240,16 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnNotPreviousSurveyedButInitialDelayInFuture() {
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: nil)
         eligibility.setLastSurveyedDate(defaults: defaults, date: nil)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -260,10 +260,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-        
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.initialDelay = failedReason {
                 // Success
@@ -272,18 +272,18 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testPassOnNotPreviousSurveyedButInitialDelayInPast() {
         let dateAnHourAgo = Date().addingTimeInterval(-61)
-        
+
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
         eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -294,25 +294,25 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let passExpectation = expectation(description: "Pass")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
             passExpectation.fulfill()
-        }) { (failedStep) in
-            
+        }) { (_) in
+
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnUnderRecurringTime() {
         let dateAnHourAgo = Date().addingTimeInterval(-59)
-        
+
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
         eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -323,10 +323,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.recurringPeriod = failedReason {
                 // Success
@@ -335,18 +335,18 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testPassOnRecurring() {
         let dateAnHourAgo = Date().addingTimeInterval(-61)
-        
+
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
         eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -357,25 +357,25 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let passExpectation = expectation(description: "Pass")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
             passExpectation.fulfill()
-        }) { (failedStep) in
-            
+        }) { (_) in
+
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnRecurringTimeLessThanMinimum() {
         let dateAnHourAgo = Date().addingTimeInterval(-61)
-        
+
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
         eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -386,10 +386,10 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
+
         }) { (failedReason) in
             if case ClientEligibility.FailedReason.recurringLessThanMinimum = failedReason {
                 // Success
@@ -398,18 +398,18 @@ class ClientEligibilityTests: XCTestCase {
             }
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
-    
+
     func testFailOnSampleFactor() {
         let dateAnHourAgo = Date().addingTimeInterval(-61)
-        
+
         let eligibility = ClientEligibility(preSurveySession: preSurveySession)
         let defaults = eligibility.getDefaults(with: configuration)
         eligibility.setFirstSeenDate(defaults: defaults, date: dateAnHourAgo)
         eligibility.setLastSurveyedDate(defaults: defaults, date: dateAnHourAgo)
-        
+
         let configuration = EligibilityConfiguration(
             surveyContextId: "",
             enabled: true,
@@ -420,14 +420,14 @@ class ClientEligibilityTests: XCTestCase {
             forceDisplay: false,
             planLimitExhausted: false
         )
-        
+
         let failExpectation = expectation(description: "Fail")
         eligibility.doClientSideCheck(eligibilityConfiguration: configuration, passed: {
-            
-        }) { (failedStep) in
+
+        }) { (_) in
             failExpectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 0.3, handler: nil)
     }
 

--- a/Example/Tests/DelightedTests.swift
+++ b/Example/Tests/DelightedTests.swift
@@ -8,7 +8,7 @@ final class DelightedTests: XCTestCase {
             XCTFail("Missing file: \(filename).json")
             return nil
         }
-        
+
         do {
             let data = try Data(contentsOf: url)
             return data
@@ -17,12 +17,12 @@ final class DelightedTests: XCTestCase {
             return nil
         }
     }
-    
+
     func testNPS() {
         let data = loadJSONData(filename: "sample_nps")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
 
@@ -30,7 +30,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "zx5K98i5YcbKqFXirpEnt5N2")
-        
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 3)
             XCTAssertEqual(surveyRequest.survey.type.id, .nps)
@@ -43,19 +43,19 @@ final class DelightedTests: XCTestCase {
             let detractor = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "detractor"
             }
-        
+
             XCTAssertEqual(promoter!.name, "promoter")
             XCTAssertEqual(promoter!.scoreMin, 9)
             XCTAssertEqual(promoter!.scoreMax, 10)
-            
+
             XCTAssertEqual(passive!.name, "passive")
             XCTAssertEqual(passive!.scoreMin, 7)
             XCTAssertEqual(passive!.scoreMax, 8)
-            
+
             XCTAssertEqual(detractor!.name, "detractor")
             XCTAssertEqual(detractor!.scoreMin, 0)
             XCTAssertEqual(detractor!.scoreMax, 6)
-        
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -69,27 +69,27 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "Not likely")
             XCTAssertEqual(configuration.veryLikelyText, "Very likely")
-            
+
             // Pusher
             let pusher = configuration.pusher
             XCTAssertEqual(pusher.webSocketUrl, "wss://example.com/ws")
             XCTAssertEqual(pusher.enabled, false)
             XCTAssertEqual(pusher.channelName, "private-channel")
-            
+
             // Theme
             let theme = configuration.theme
             XCTAssertNotNil(theme)
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "How likely are you to recommend Hem & Stitch NPS to a friend?")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 11)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 6)
-            
+
             let question1 = additionalQuestions[0]
             XCTAssertEqual(question1.id, "271")
             XCTAssertEqual(question1.type, .selectOne)
@@ -98,14 +98,14 @@ final class DelightedTests: XCTestCase {
             XCTAssertNil(question1.scaleMax)
             XCTAssertNil(question1.scaleMinLabel)
             XCTAssertNil(question1.scaleMaxLabel)
-            
+
             let question1Options = question1.options
             XCTAssertEqual(question1Options?.count, 2)
             XCTAssertEqual(question1Options?[0].id, "512")
             XCTAssertEqual(question1Options?[0].text, "Yes")
             XCTAssertEqual(question1Options?[1].id, "513")
             XCTAssertEqual(question1Options?[1].text, "No")
-            
+
             let question2 = additionalQuestions[1]
             XCTAssertEqual(question2.id, "272")
             XCTAssertEqual(question2.type, .selectMany)
@@ -114,10 +114,10 @@ final class DelightedTests: XCTestCase {
             XCTAssertNil(question2.scaleMax)
             XCTAssertNil(question2.scaleMinLabel)
             XCTAssertNil(question2.scaleMaxLabel)
-            
+
             let question2Options = question2.options
             XCTAssertEqual(question2Options?.count, 4)
-            
+
             let question3 = additionalQuestions[2]
             XCTAssertEqual(question3.id, "273")
             XCTAssertEqual(question3.type, .freeResponse)
@@ -126,14 +126,14 @@ final class DelightedTests: XCTestCase {
             XCTAssertNil(question3.scaleMax)
             XCTAssertNil(question3.scaleMinLabel)
             XCTAssertNil(question3.scaleMaxLabel)
-            
+
             let question3Options = question3.options
             XCTAssertNil(question3Options)
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 3)
             let thankYouPromoter = surveyRequest.thankYou.groups.first { (group) -> Bool in
                 return group.name == "promoter"
@@ -144,37 +144,37 @@ final class DelightedTests: XCTestCase {
             let thankYouDetractor = surveyRequest.thankYou.groups.first { (group) -> Bool in
                 return group.name == "detractor"
             }
-            
+
             XCTAssertEqual(thankYouPromoter!.name, "promoter")
             XCTAssertEqual(thankYouPromoter!.messageText, "PROMOTERS: Please take a moment and share your experience on Yelp.")
             XCTAssertEqual(thankYouPromoter!.linkText, "Review us on Yelp!")
             XCTAssertEqual(thankYouPromoter!.linkURL, "https://yelp.com")
-            
+
             XCTAssertEqual(thankYouPassive!.name, "passive")
             XCTAssertEqual(thankYouPassive!.messageText, "PASSIVES: Please take a moment and share your experience on Yelp.")
             XCTAssertEqual(thankYouPassive!.linkText, "Review us on Yelp!")
             XCTAssertEqual(thankYouPassive!.linkURL, "https://yelp.com")
-            
+
             XCTAssertEqual(thankYouDetractor!.name, "detractor")
             XCTAssertEqual(thankYouDetractor!.messageText, "DETRACTORS: Please take a moment and share your experience on Yelp.")
             XCTAssertEqual(thankYouDetractor!.linkText, "Review us on Yelp!")
             XCTAssertEqual(thankYouDetractor!.linkURL, "https://yelp.com")
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testTheme() {
         let data = loadJSONData(filename: "sample_nps")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
             let configuration = surveyRequest.survey.configuration
-            
+
             // Theme
             let theme = configuration.theme
             XCTAssertEqual(theme.primaryColor.color, UIColor(hex: "#1DA2F1"))
@@ -185,22 +185,22 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(theme.backgroundColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(theme.primaryTextColor.color, UIColor(hex: "#1D1D1D"))
             XCTAssertEqual(theme.secondaryTextColor.color, UIColor(hex: "#999999"))
-            
+
             let textArea = theme.textarea
             XCTAssertEqual(textArea.backgroundColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(textArea.textColor.color, UIColor(hex: "#1D1D1D"))
             XCTAssertEqual(textArea.borderColor.color, UIColor(hex: "#999999"))
-            
+
             let primaryButton = theme.primaryButton
             XCTAssertEqual(primaryButton.backgroundColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(primaryButton.textColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(primaryButton.borderColor.color, UIColor(hex: "#1DA2F1"))
-            
+
             let secondaryButton = theme.secondaryButton
             XCTAssertEqual(secondaryButton.backgroundColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(secondaryButton.textColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(secondaryButton.borderColor.color, UIColor(hex: "#1DA2F1"))
-            
+
             let button = theme.button
             XCTAssertEqual(button.activeBackgroundColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(button.activeTextColor.color, UIColor(hex: "#FFFFFF"))
@@ -208,15 +208,15 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(button.inactiveBackgroundColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(button.inactiveTextColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(button.inactiveBorderColor.color, UIColor(hex: "#1DA2F1"))
-            
+
             let stars = theme.stars
             XCTAssertEqual(stars.activeBackgroundColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(stars.inactiveBackgroundColor.color, UIColor(hex: "#FFFFFF"))
-            
+
             let icon = theme.icon
             XCTAssertEqual(icon.activeBackgroundColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(icon.inactiveBackgroundColor.color, UIColor(hex: "#DDDDDD"))
-            
+
             let scale = theme.scale
             XCTAssertEqual(scale.activeBackgroundColor.color, UIColor(hex: "#00faff"))
             XCTAssertEqual(scale.activeTextColor.color, UIColor(hex: "#000000"))
@@ -224,7 +224,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(scale.inactiveBackgroundColor.color, UIColor(hex: "#ffee00"))
             XCTAssertEqual(scale.inactiveTextColor.color, UIColor(hex: "#000000"))
             XCTAssertEqual(scale.inactiveBorderColor.color, UIColor(hex: "#f21d1d"))
-            
+
             let slider = theme.slider
             XCTAssertEqual(slider.knobBackgroundColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(slider.knobTextColor.color, UIColor(hex: "#FFFFFF"))
@@ -234,7 +234,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(slider.hoverBackgroundColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(slider.hoverTextColor.color, UIColor(hex: "#1DA2F1"))
             XCTAssertEqual(slider.hoverBorderColor.color, UIColor(hex: "#1DA2F1"))
-            
+
             let closeButton = theme.closeButton
             XCTAssertEqual(closeButton.normalBackgroundColor.color, UIColor(hex: "#1D1D1D"))
             XCTAssertEqual(closeButton.normalTextColor.color, UIColor(hex: "#FFFFFF"))
@@ -242,7 +242,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(closeButton.highlightedBackgroundColor.color, UIColor(hex: "#999999"))
             XCTAssertEqual(closeButton.highlightedTextColor.color, UIColor(hex: "#FFFFFF"))
             XCTAssertEqual(closeButton.highlightedBorderColor.color, UIColor(hex: "#999999"))
-            
+
             let ios = theme.ios
             XCTAssertEqual(ios.keyboardAppearance, nil)
             XCTAssertEqual(ios.statusBarMode, .darkContent)
@@ -252,20 +252,20 @@ final class DelightedTests: XCTestCase {
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testFiveStar() {
         let data = loadJSONData(filename: "sample_five_star")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-            
+
             // Token
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "IvDpINRwBfWxy8vreolJVAdI")
-            
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 5)
             XCTAssertEqual(surveyRequest.survey.type.id, .starsFive)
@@ -284,27 +284,27 @@ final class DelightedTests: XCTestCase {
             let star1 = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "star_1"
             }
-            
+
             XCTAssertEqual(star5!.name, "star_5")
             XCTAssertEqual(star5!.scoreMin, 5)
             XCTAssertEqual(star5!.scoreMax, 5)
-            
+
             XCTAssertEqual(star4!.name, "star_4")
             XCTAssertEqual(star4!.scoreMin, 4)
             XCTAssertEqual(star4!.scoreMax, 4)
-            
+
             XCTAssertEqual(star3!.name, "star_3")
             XCTAssertEqual(star3!.scoreMin, 3)
             XCTAssertEqual(star3!.scoreMax, 3)
-            
+
             XCTAssertEqual(star2!.name, "star_2")
             XCTAssertEqual(star2!.scoreMin, 2)
             XCTAssertEqual(star2!.scoreMax, 2)
-            
+
             XCTAssertEqual(star1!.name, "star_1")
             XCTAssertEqual(star1!.scoreMin, 1)
             XCTAssertEqual(star1!.scoreMax, 1)
-            
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -318,17 +318,17 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "1 star")
             XCTAssertEqual(configuration.veryLikelyText, "5 stars")
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "How would you rate your experience with Hem & Stitch 5-star?")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 5)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 6)
-            
+
             let question1 = additionalQuestions[0]
             XCTAssertEqual(question1.id, "199")
             XCTAssertEqual(question1.type, .selectOne)
@@ -337,7 +337,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertNil(question1.scaleMax)
             XCTAssertNil(question1.scaleMinLabel)
             XCTAssertNil(question1.scaleMaxLabel)
-            
+
             let question2 = additionalQuestions[1]
             XCTAssertEqual(question2.id, "200")
             XCTAssertEqual(question2.type, .selectMany)
@@ -346,7 +346,7 @@ final class DelightedTests: XCTestCase {
             XCTAssertNil(question2.scaleMax)
             XCTAssertNil(question2.scaleMinLabel)
             XCTAssertNil(question2.scaleMaxLabel)
-            
+
             let question3 = additionalQuestions[2]
             XCTAssertEqual(question3.id, "201")
             XCTAssertEqual(question3.type, .scale)
@@ -355,32 +355,32 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(question3.scaleMax, 10)
             XCTAssertEqual(question3.scaleMinLabel, "Very difficult")
             XCTAssertEqual(question3.scaleMaxLabel, "Very easy")
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 0)
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testCSAT() {
         let data = loadJSONData(filename: "sample_csat")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-            
+
             // Token
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "A5s1Cq1Al339fs1KU46JelCL")
-            
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 3)
             XCTAssertEqual(surveyRequest.survey.type.id, .csat)
@@ -393,19 +393,19 @@ final class DelightedTests: XCTestCase {
             let dissatisfied = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "dissatisfied"
             }
-            
+
             XCTAssertEqual(satisfied!.name, "satisfied")
             XCTAssertEqual(satisfied!.scoreMin, 4)
             XCTAssertEqual(satisfied!.scoreMax, 5)
-            
+
             XCTAssertEqual(neutral!.name, "neutral")
             XCTAssertEqual(neutral!.scoreMin, 3)
             XCTAssertEqual(neutral!.scoreMax, 3)
-            
+
             XCTAssertEqual(dissatisfied!.name, "dissatisfied")
             XCTAssertEqual(dissatisfied!.scoreMin, 1)
             XCTAssertEqual(dissatisfied!.scoreMax, 2)
-            
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -419,42 +419,42 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "Very dissatisfied")
             XCTAssertEqual(configuration.veryLikelyText, "Very satisfied")
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "How satisfied were you with Hem & Stitch CSAT?")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 5)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 3)
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 0)
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testCES() {
         let data = loadJSONData(filename: "sample_ces")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-            
+
             // Token
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "q8PSgeqqIJYlcDx2NBEU9UNe")
-            
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 3)
             XCTAssertEqual(surveyRequest.survey.type.id, .ces)
@@ -467,19 +467,19 @@ final class DelightedTests: XCTestCase {
             let disagree = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "disagree"
             }
-            
+
             XCTAssertEqual(agree!.name, "agree")
             XCTAssertEqual(agree!.scoreMin, 4)
             XCTAssertEqual(agree!.scoreMax, 5)
-            
+
             XCTAssertEqual(neutral!.name, "neutral")
             XCTAssertEqual(neutral!.scoreMin, 3)
             XCTAssertEqual(neutral!.scoreMax, 3)
-            
+
             XCTAssertEqual(disagree!.name, "disagree")
             XCTAssertEqual(disagree!.scoreMin, 1)
             XCTAssertEqual(disagree!.scoreMax, 2)
-            
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -493,42 +493,42 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "Strongly disagree")
             XCTAssertEqual(configuration.veryLikelyText, "Strongly agree")
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "Hem & Stitch CES made it easy for me to handle my issue.")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 5)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 3)
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 0)
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testSmileys() {
         let data = loadJSONData(filename: "sample_smileys")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-            
+
             // Token
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "yGRn3MLbgVAIF6HlMQ37j3tl")
-            
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 5)
             XCTAssertEqual(surveyRequest.survey.type.id, .smileys)
@@ -547,27 +547,27 @@ final class DelightedTests: XCTestCase {
             let veryUnhappy = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "very_unhappy"
             }
-            
+
             XCTAssertEqual(veryHappy!.name, "very_happy")
             XCTAssertEqual(veryHappy!.scoreMin, 5)
             XCTAssertEqual(veryHappy!.scoreMax, 5)
-            
+
             XCTAssertEqual(happy!.name, "happy")
             XCTAssertEqual(happy!.scoreMin, 4)
             XCTAssertEqual(happy!.scoreMax, 4)
-            
+
             XCTAssertEqual(neutral!.name, "neutral")
             XCTAssertEqual(neutral!.scoreMin, 3)
             XCTAssertEqual(neutral!.scoreMax, 3)
-            
+
             XCTAssertEqual(unhappy!.name, "unhappy")
             XCTAssertEqual(unhappy!.scoreMin, 2)
             XCTAssertEqual(unhappy!.scoreMax, 2)
-            
+
             XCTAssertEqual(veryUnhappy!.name, "very_unhappy")
             XCTAssertEqual(veryUnhappy!.scoreMin, 1)
             XCTAssertEqual(veryUnhappy!.scoreMax, 1)
-            
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -581,42 +581,42 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "Very unhappy")
             XCTAssertEqual(configuration.veryLikelyText, "Very happy")
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "How happy were you with Hem & Stitch Smileys?")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 5)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 6)
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 0)
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
         }
     }
-    
+
     func testThumbs() {
         let data = loadJSONData(filename: "sample_thumbs")!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         do {
             let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-            
+
             // Token
             XCTAssertNotNil(surveyRequest)
             XCTAssertNotNil(surveyRequest.token)
             XCTAssertEqual(surveyRequest.token, "vGFlRckNlivGCUeFdmNVoJlB")
-            
+
             // Survey type
             XCTAssertEqual(surveyRequest.survey.type.groups.count, 2)
             XCTAssertEqual(surveyRequest.survey.type.id, .thumbs)
@@ -626,15 +626,15 @@ final class DelightedTests: XCTestCase {
             let thumbsDown = surveyRequest.survey.type.groups.first { (group) -> Bool in
                 return group.name == "thumbs_down"
             }
-            
+
             XCTAssertEqual(thumbsUp!.name, "thumbs_up")
             XCTAssertEqual(thumbsUp!.scoreMin, 1)
             XCTAssertEqual(thumbsUp!.scoreMax, 1)
-            
+
             XCTAssertEqual(thumbsDown!.name, "thumbs_down")
             XCTAssertEqual(thumbsDown!.scoreMin, 0)
             XCTAssertEqual(thumbsDown!.scoreMax, 0)
-            
+
             // Survey configuration
             let configuration = surveyRequest.survey.configuration
             XCTAssertEqual(configuration.textBaseDirection, .ltr)
@@ -648,23 +648,23 @@ final class DelightedTests: XCTestCase {
             XCTAssertEqual(configuration.doneText, "Done")
             XCTAssertEqual(configuration.notLikelyText, "Thumbs down")
             XCTAssertEqual(configuration.veryLikelyText, "Thumbs up")
-            
+
             // Survey template
             let template = surveyRequest.survey.template
             XCTAssertEqual(template.questionText, "How was your experience with Hem & Stitch Thumbs?")
-            
+
             let commentPrompts = surveyRequest.survey.template.commentPrompts
             XCTAssertEqual(commentPrompts.count, 2)
-            
+
             let additionalQuestions = template.additionalQuestions
             XCTAssertEqual(additionalQuestions.count, 0)
-            
+
             // Thank you
             let thankYou = surveyRequest.thankYou
             XCTAssertEqual(thankYou.text, "Thanks, we really appreciate your feedback.")
-            
+
             XCTAssertEqual(surveyRequest.thankYou.groups.count, 0)
-            
+
         } catch {
             print(error.localizedDescription)
             XCTFail("Failed to create surveyRequest")
@@ -677,6 +677,6 @@ final class DelightedTests: XCTestCase {
         ("testCSAT", testCSAT),
         ("testCES", testCES),
         ("testSmileys", testSmileys),
-        ("testThumbs", testThumbs),
+        ("testThumbs", testThumbs)
     ]
 }

--- a/Example/Tests/XCTestManifests.swift
+++ b/Example/Tests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(DelightedTests.allTests),
+        testCase(DelightedTests.allTests)
     ]
 }
 #endif

--- a/Example/delighted/DemoViewController.swift
+++ b/Example/delighted/DemoViewController.swift
@@ -3,12 +3,12 @@ import Delighted
 
 class DemoViewController: UIViewController {
     var example: Example?
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = true
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = false
@@ -27,9 +27,9 @@ class DemoViewController: UIViewController {
             initialDelay: nil,
             recurringPeriod: nil
         )
-        
+
         Delighted.survey(delightedID: delightedID, person: person, properties: properties, options: options, eligibilityOverrides: eligibilityOverrides, inViewController: nil, callback: { [unowned self] (status) in
-            
+
             switch status {
             case let .failedClientEligibility(error):
                 print("failedClientEligibility: \(error)")
@@ -41,7 +41,7 @@ class DemoViewController: UIViewController {
             self.performSegue(withIdentifier: "unwindToExamples", sender: self)
         })
     }
-    
+
     func setExample(example: Example) {
         print("Showing example of \(example.label)")
         self.example = example

--- a/Example/delighted/ExamplesViewController.swift
+++ b/Example/delighted/ExamplesViewController.swift
@@ -11,7 +11,7 @@ struct Example {
 
 enum Section: Int {
     case surveyTypes = 0, other
-    
+
     var title: String {
         switch self {
         case .surveyTypes:
@@ -23,13 +23,13 @@ enum Section: Int {
 }
 
 class ExamplesViewController: UITableViewController {
-    @IBAction func unwindToExamples(segue:UIStoryboardSegue) { }
-    
+    @IBAction func unwindToExamples(segue: UIStoryboardSegue) { }
+
     @IBOutlet var examplesTableView: UITableView!
-    
+
     public var selectedExample: Example?
 
-    let examples: [Section:[Example]] = [
+    let examples: [Section: [Example]] = [
         .surveyTypes: [
             Example(
                 label: "NPS",
@@ -141,13 +141,13 @@ class ExamplesViewController: UITableViewController {
             )
         ]
     ]
-    
+
     func getExample(indexPath: IndexPath) -> Example {
         return examples[Section(rawValue: indexPath.section)!]![indexPath.row]
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return examples.count;
+        return examples.count
     }
 
     // Section label
@@ -155,12 +155,12 @@ class ExamplesViewController: UITableViewController {
                                 section: Int) -> String? {
         return Section(rawValue: section)!.title
     }
-    
+
     // Number of examples in section
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return examples[Section(rawValue: section)!]!.count
     }
-    
+
     // Given an indexPath (section, row), construct a cell
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = examplesTableView.dequeueReusableCell(withIdentifier: "ExampleCell", for: indexPath)
@@ -178,7 +178,7 @@ class ExamplesViewController: UITableViewController {
         selectedExample = getExample(indexPath: indexPath)
         self.performSegue(withIdentifier: "demoSurvey", sender: examplesTableView.cellForRow(at: indexPath))
     }
-    
+
     // Before transitioning, set the example that'll be demo'd
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "demoSurvey" {

--- a/delighted/Classes/API.swift
+++ b/delighted/Classes/API.swift
@@ -160,9 +160,7 @@ extension Request {
             }
 
             // make the request
-            let task = Request.session.dataTask(with: urlRequest) {
-                (data, response, _) in
-
+            let task = Request.session.dataTask(with: urlRequest) { (data, response, _) in
                 // Verify a data and a response
                 guard let data = data, let response = response as? HTTPURLResponse else {
                     RequestCache.store(request: self)
@@ -287,7 +285,7 @@ extension RequestCache {
             request.send(completion: { (_, _) in
                 // Remove file if sent successfully
                 RequestCache.remove(request: request)
-            }) { (_) in
+            }, failure: { (_) in
                 // Decrement count and remove if down to 0
                 var failedAgainRequest = request
                 failedAgainRequest.retryCount -= 1
@@ -297,7 +295,7 @@ extension RequestCache {
                 } else {
                     RequestCache.store(request: failedAgainRequest)
                 }
-            }
+            })
         }
     }
 }

--- a/delighted/Classes/API.swift
+++ b/delighted/Classes/API.swift
@@ -13,14 +13,14 @@ enum Route {
     case surveyResponse(surveyResponse: SurveyResponse)
     case eligibilityConfiguration
     case pusherAuth(pusherAuthRequest: PusherAuthRequest)
-    
+
     var useCDN: Bool {
         switch self {
         case .eligibilityConfiguration: return true
         default: return false
         }
     }
-    
+
     var path: String {
         switch self {
         case .surveyRequest: return "/survey_requests"
@@ -29,7 +29,7 @@ enum Route {
         case .pusherAuth: return "/pusher/auth"
         }
     }
-    
+
     var method: String {
         switch self {
         case .surveyRequest: return "POST"
@@ -38,14 +38,14 @@ enum Route {
         case .pusherAuth: return "POST"
         }
     }
-    
+
     var accept: String? {
         switch self {
         case .surveyRequest, .surveyResponse, .eligibilityConfiguration, .pusherAuth:
             return "application/json"
         }
     }
-    
+
     var contentType: String? {
         switch self {
         case .surveyRequest, .surveyResponse, .pusherAuth:
@@ -54,7 +54,7 @@ enum Route {
             return nil
         }
     }
-    
+
     var offlineSaveID: String? {
         switch self {
         case let .surveyResponse(surveyResponse):
@@ -63,11 +63,11 @@ enum Route {
             return nil
         }
     }
-    
+
     func makeBody() throws -> Data? {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        
+
         switch self {
         case let .surveyRequest(surveyRequestBody):
             return try encoder.encode(surveyRequestBody)
@@ -98,22 +98,22 @@ struct Request: Codable {
     let accept: String?
     let contentType: String?
     let body: Data?
-    
+
     let offlineSaveID: String?
     var retryCount: Int = 5
-    
+
     var userAgent: String {
         return "DelightedSDK/\(VERSION) (iPhone; iOS \(UIDevice.current.systemVersion))"
     }
-    
+
     static var session: URLSession = {
         let config = URLSessionConfiguration.default
         return URLSession(configuration: config)
     }()
-    
+
     init(baseURL: URL, route: Route) throws {
         let url = baseURL.appendingPathComponent(route.path)
-        
+
         self.url = url
         self.method = route.method
         self.accept = route.accept
@@ -121,21 +121,21 @@ struct Request: Codable {
         self.body = try route.makeBody()
         self.offlineSaveID = route.offlineSaveID
     }
-    
+
     private func makeURLRequest() throws -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
-        
+
         if let accept = accept {
             request.addValue(accept, forHTTPHeaderField: "Accept")
         }
         if let contentType = contentType {
             request.addValue(contentType, forHTTPHeaderField: "Content-Type")
         }
-        
+
         request.httpBody = body
-        
+
         return request
     }
 }
@@ -150,36 +150,36 @@ extension Request {
      5. Attempts removes from offline cache (since this may have been a retry
      6. Completion block called
      */
-    func send(completion: @escaping (Data?, HTTPURLResponse?) -> (), failure: @escaping (Error) -> ()) {
+    func send(completion: @escaping (Data?, HTTPURLResponse?) -> Void, failure: @escaping (Error) -> Void) {
         do {
             let urlRequest = try makeURLRequest()
-            
+
             Logger.log(.debug, "\(urlRequest.httpMethod ?? "") \(urlRequest.url?.absoluteString ?? "")")
             if let data = urlRequest.httpBody, let body = String(bytes: data, encoding: .utf8) {
                 Logger.log(.debug, "\t\(body)")
             }
-            
+
             // make the request
             let task = Request.session.dataTask(with: urlRequest) {
-                (data, response, error) in
-                
+                (data, response, _) in
+
                 // Verify a data and a response
                 guard let data = data, let response = response as? HTTPURLResponse else {
                     RequestCache.store(request: self)
                     failure(APIError.noResponse)
                     return
                 }
-                
+
                 let requestID = response.allHeaderFields["X-Request-Id"] ?? ""
                 Logger.log(.debug, "\(requestID) \(urlRequest.httpMethod ?? "") \(urlRequest.url?.absoluteString ?? "") - \(response.statusCode)")
-                
+
                 // Verify a 2XX
                 guard 200...299 ~= response.statusCode else {
                     RequestCache.store(request: self)
                     failure(APIError.badRequest(response.statusCode, data, response))
                     return
                 }
-                
+
                 RequestCache.remove(request: self)
                 completion(data, response)
             }
@@ -196,11 +196,11 @@ extension Request {
  */
 struct RequestCache {
     static let fileExtension = "json"
-    
+
     static var directoryURL: URL? = {
         return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent("delighted")
     }()
-    
+
     /**
      Finds all files and decodes them into Request objects
      */
@@ -208,27 +208,27 @@ struct RequestCache {
         guard let directoryURL = RequestCache.directoryURL else {
             return []
         }
-        
+
         // Get list of file paths for requests saved that need resending
         let urls = try? FileManager.default.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: nil)
-        
+
         // Maps file paths to decoded request objects
         return urls?.compactMap { (url) -> Request? in
             if !FileManager.default.fileExists(atPath: url.path) {
                 return nil
             }
-            
+
             if let data = FileManager.default.contents(atPath: url.path) {
                 let decoder = JSONDecoder()
                 let model = try? decoder.decode(Request.self, from: data)
                 return model
             }
-            
+
             return nil
         } ?? []
-        
+
     }
-    
+
     /**
      Writes the Request to disk (if offlineSaveID exists)
      */
@@ -236,16 +236,16 @@ struct RequestCache {
         guard let directoryURL = RequestCache.directoryURL, let filename = request.offlineSaveID else {
             return
         }
-        
+
         let fileURL = directoryURL
             .appendingPathComponent(filename)
             .appendingPathExtension(fileExtension)
-        
+
         // Create cache directory if it doesn't exist
         if !FileManager.default.fileExists(atPath: directoryURL.absoluteString) {
             try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
         }
-        
+
         // Attempt to encode the request to save for sending later
         let encoder = JSONEncoder()
         do {
@@ -258,7 +258,7 @@ struct RequestCache {
             Logger.log(.error, error.localizedDescription)
         }
     }
-    
+
     /**
      Attempts to remove the Request (if offlineSaveID exists) from disk
      */
@@ -266,11 +266,11 @@ struct RequestCache {
         guard let directoryURL = RequestCache.directoryURL, let filename = request.offlineSaveID else {
             return
         }
-        
+
         let fileURL = directoryURL
             .appendingPathComponent(filename)
             .appendingPathExtension(fileExtension)
-        
+
         // Delete the file if it eists
         if FileManager.default.fileExists(atPath: fileURL.path) {
             try? FileManager.default.removeItem(at: fileURL)
@@ -281,7 +281,7 @@ struct RequestCache {
 extension RequestCache {
     static func retryAll() {
         let requests = RequestCache.all()
-        
+
         // Iterate over requests and attempt to send
         for request in requests {
             request.send(completion: { (_, _) in
@@ -291,7 +291,7 @@ extension RequestCache {
                 // Decrement count and remove if down to 0
                 var failedAgainRequest = request
                 failedAgainRequest.retryCount -= 1
-                
+
                 if failedAgainRequest.retryCount <= 0 {
                     RequestCache.remove(request: failedAgainRequest)
                 } else {

--- a/delighted/Classes/AdditionalQuestionViewController.swift
+++ b/delighted/Classes/AdditionalQuestionViewController.swift
@@ -7,21 +7,21 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
     let question: Survey.Template.AdditionalQuestion
     let isFirstQuestion: Bool
     let isLastQuestion: Bool
-    
+
     var survey: Survey {
         return session.surveyRequest.survey
     }
-    
+
     var configuration: Configuration {
         return session.configuration
     }
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
+
     let footerBottomMarging: CGFloat = 20
-    
+
     init(pageViewController: DelightedPageViewController, session: SurveySession, question: Survey.Template.AdditionalQuestion, isFirstQuestion: Bool, isLastQuestion: Bool) {
         self.pageViewController = pageViewController
         self.session = session
@@ -30,34 +30,34 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         self.isLastQuestion = isLastQuestion
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupView()
     }
-    
+
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if componentHasKeyboard {
             registerNotifications()
         }
     }
-    
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         if componentHasKeyboard {
             // Needs to async due to page view controller transitions
             DispatchQueue.main.async {
                 self.textArea.becomeFirstResponder()
             }
         }
-        
+
         switch question.type {
         case .scale:
             scale.adjustForInitialDisplay()
@@ -65,12 +65,12 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
             ()
         }
     }
-    
+
     public override func viewWillDisappear(_ animated: Bool) {
         textArea.endEditing(true)
         super.viewWillDisappear(animated)
     }
-    
+
     override public func viewDidDisappear(_ animated: Bool) {
         unregisterNotifications()
         super.viewDidDisappear(animated)
@@ -85,13 +85,13 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         label.textColor = theme.primaryTextColor.color
         return label
     }()
-    
+
     private lazy var footerContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var singleSelect: OptionSelect = {
         let view = OptionSelect(
             configuration: configuration,
@@ -102,18 +102,18 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var multiSelect: OptionSelect = {
         let view = OptionSelect(
             configuration: configuration,
             question: question,
-            mode: .multi)  { [weak self] (options) in
+            mode: .multi) { [weak self] (options) in
                 self?.addAnswer(options: options)
         }
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var textArea: TextArea = {
         let view = TextArea(configuration: configuration, onSelection: { [weak self] (text) in
             self?.addAnswer(value: text)
@@ -121,7 +121,7 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var scale: Scale = {
         let view = Scale(
             configuration: configuration,
@@ -135,7 +135,7 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var component: UIView = {
         let component: UIView
         switch question.type {
@@ -150,76 +150,76 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
         }
         return component
     }()
-    
+
     private lazy var nextButton: UIButton = {
         let button = Button(configuration: configuration, mode: .primary)
         button.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.setTitle(configuration.nextText, for: .normal)
         button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
-        
+
         button.layer.masksToBounds = true
         button.layer.cornerRadius = Configuration.cornerRadius
         button.addTarget(self, action: #selector(onNext(sender:)), for: .touchUpInside)
-        
+
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .center
-        
+
         return button
     }()
-    
+
     private lazy var previousButton: UIButton = {
         let button = Button(configuration: configuration, mode: .secondary)
         button.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.setTitle(configuration.prevText, for: .normal)
         button.contentEdgeInsets = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
-        
+
         button.layer.masksToBounds = true
         button.layer.cornerRadius = Configuration.cornerRadius
         button.addTarget(self, action: #selector(onPrevious(sender:)), for: .touchUpInside)
-        
+
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .center
-        
+
         return button
     }()
-    
+
     private lazy var poweredByLabel: PoweredBy = {
         let button = PoweredBy(configuration: self.configuration)
         return button
     }()
-    
+
     private lazy var footerBottomConstraint: NSLayoutConstraint = {
         let constant = componentHasKeyboard ? KeyboardHeightHistory.lastHeight ?? 0 : 0
-        
+
        return footerContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -(constant + footerBottomMarging))
     }()
-    
+
     private lazy var componentHasKeyboard: Bool = {
         switch question.type {
         case .freeResponse: return true
         case .selectOne, .selectMany, .scale: return false
         }
     }()
-    
+
     @objc func onNext(sender: Any?) {
         session.sendClientTyping()
         session.saveSurveyResponse()
-        
+
         if isLastQuestion {
             pageViewController.state = .thankYou
         } else {
             pageViewController.nextPage()
         }
     }
-    
+
     @objc func onPrevious(sender: Any?) {
         session.sendClientTyping()
-        
+
         pageViewController.previousPage()
     }
-    
+
     @objc func onClose(sender: Any?) {
         dismiss(animated: true)
     }
@@ -229,10 +229,10 @@ private extension AdditionalQuestionViewController {
     private func addAnswer(options: [Survey.Template.AdditionalQuestion.Option]) {
         let value = options.map({ $0.id }).joined(separator: ",")
         addAnswer(value: value)
-        
+
         session.sendClientTyping()
     }
-    
+
     private func addAnswer(value: String) {
         session.surveyResponse.addAnswer(id: question.id, value: value)
     }
@@ -248,7 +248,7 @@ private extension AdditionalQuestionViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         #endif
     }
-    
+
     func unregisterNotifications() {
         #if swift(>=4.2)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -258,21 +258,21 @@ private extension AdditionalQuestionViewController {
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         #endif
     }
-    
-    @objc func keyboardWillShow(notification: NSNotification){
+
+    @objc func keyboardWillShow(notification: NSNotification) {
         #if swift(>=4.2)
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         #else
         guard let keyboardFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue else { return }
         #endif
-        
+
         let height = self.view.convert(keyboardFrame.cgRectValue, from: nil).size.height
         KeyboardHeightHistory.lastHeight = height
-        
+
         footerBottomConstraint.constant = -(height + footerBottomMarging)
     }
-    
-    @objc func keyboardWillHide(notification: NSNotification){
+
+    @objc func keyboardWillHide(notification: NSNotification) {
 
     }
 }
@@ -280,30 +280,30 @@ private extension AdditionalQuestionViewController {
 private extension AdditionalQuestionViewController {
     func setupView() {
         view.backgroundColor = theme.backgroundColor.color
-        
+
         view.addSubview(questionLabel)
         view.addSubview(footerContainer)
         footerContainer.addSubview(previousButton)
         footerContainer.addSubview(nextButton)
         footerContainer.addSubview(poweredByLabel)
-        
+
         let text = question.text
         questionLabel.attributedText = text.setParagraphStyle(lineSpacing: 3, alignment: .center)
-        
+
         if isLastQuestion {
             nextButton.setTitle(configuration.doneText, for: .normal)
         }
-        
+
         NSLayoutConstraint.activate([
             questionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             questionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
             questionLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 90),
-            
+
             footerContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             footerContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
             footerBottomConstraint
         ])
-        
+
         if isFirstQuestion {
             previousButton.isHidden = true
             NSLayoutConstraint.activate([
@@ -318,29 +318,29 @@ private extension AdditionalQuestionViewController {
                 previousButton.trailingAnchor.constraint(equalTo: footerContainer.centerXAnchor, constant: -10),
                 previousButton.topAnchor.constraint(equalTo: footerContainer.topAnchor),
                 previousButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 50),
-                
-                nextButton.leadingAnchor.constraint(equalTo: footerContainer.centerXAnchor,constant: 10),
+
+                nextButton.leadingAnchor.constraint(equalTo: footerContainer.centerXAnchor, constant: 10),
                 nextButton.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor),
                 nextButton.topAnchor.constraint(equalTo: footerContainer.topAnchor),
                 nextButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 50),
-                
+
                 previousButton.heightAnchor.constraint(equalTo: nextButton.heightAnchor)
             ])
         }
-        
+
         NSLayoutConstraint.activate([
             poweredByLabel.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor),
             poweredByLabel.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor),
             poweredByLabel.topAnchor.constraint(equalTo: nextButton.bottomAnchor, constant: 20),
-            poweredByLabel.bottomAnchor.constraint(equalTo: footerContainer.bottomAnchor),
+            poweredByLabel.bottomAnchor.constraint(equalTo: footerContainer.bottomAnchor)
         ])
-        
+
         setupComponent()
     }
-    
+
     func setupComponent() {
         view.addSubview(component)
-        
+
         let bottomConstraint: NSLayoutConstraint = {
             switch component {
             case is OptionSelect:
@@ -349,7 +349,7 @@ private extension AdditionalQuestionViewController {
                 return component.bottomAnchor.constraint(lessThanOrEqualTo: footerContainer.topAnchor, constant: -20)
             }
         }()
-        
+
         NSLayoutConstraint.activate([
             component.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             component.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),

--- a/delighted/Classes/Button.swift
+++ b/delighted/Classes/Button.swift
@@ -21,29 +21,29 @@ class TintStateButton: UIButton {
                updateTint()
            }
        }
-    
+
     init() {
         super.init(frame: .zero)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override var isSelected: Bool {
         willSet {
             super.isSelected = newValue
             updateTint()
         }
     }
-    
+
     override var isHighlighted: Bool {
         willSet {
             super.isHighlighted = newValue
             updateTint()
         }
     }
-    
+
     private func updateTint() {
         switch (isSelected, isHighlighted) {
         case (false, false):
@@ -59,37 +59,37 @@ class TintStateButton: UIButton {
 }
 
 class Button: UIButton {
-    
+
     let configuration: Configuration
     let mode: Mode
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
+
     enum Mode {
         case primary, secondary, scale, button
     }
-    
+
     init(configuration: Configuration, mode: Mode) {
         self.configuration = configuration
         self.mode = mode
         super.init(frame: .zero)
-        
+
         self.titleLabel?.numberOfLines = 0
         self.titleLabel?.textAlignment = .center
         self.contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
-        
+
         apply()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         switch theme.buttonShape {
         case .circle:
             layer.cornerRadius = bounds.height / 2.0
@@ -98,7 +98,7 @@ class Button: UIButton {
         case .square:
             layer.cornerRadius = 0
         }
-        
+
         switch mode {
         case .primary:
             ()
@@ -132,7 +132,7 @@ class Button: UIButton {
             }
         }
     }
-    
+
     // Listens for changes and adjusts the inset constraints
     override var contentEdgeInsets: UIEdgeInsets {
         get {
@@ -146,27 +146,27 @@ class Button: UIButton {
             super.contentEdgeInsets = newValue
         }
     }
-    
+
     private lazy var topInsetConstraint: NSLayoutConstraint? = {
         return titleLabel?.topAnchor.constraint(equalTo: topAnchor, constant: 0)
     }()
-    
+
     private lazy var bottomInsetConstraint: NSLayoutConstraint? = {
         return titleLabel?.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0)
     }()
-    
+
     private lazy var leftInsetConstraint: NSLayoutConstraint? = {
         return titleLabel?.leftAnchor.constraint(equalTo: leftAnchor, constant: 0)
     }()
-    
+
     private lazy var rightInsetConstraint: NSLayoutConstraint? = {
         return titleLabel?.rightAnchor.constraint(equalTo: rightAnchor, constant: 0)
     }()
-    
+
     @objc func onTouchUp(sender: Any?) {
         Haptic.medium.generate()
     }
-    
+
     private func apply() {
         // Sets inset constraints that allow the button to
         // grow with titel label size
@@ -174,10 +174,10 @@ class Button: UIButton {
         bottomInsetConstraint?.isActive = true
         leftInsetConstraint?.isActive = true
         rightInsetConstraint?.isActive = true
-        
+
         layer.masksToBounds = true
         titleLabel?.font = configuration.font(ofSize: 16)
-        
+
         let titleColorNormal: UIColor
         let titleColorHightlighted: UIColor?
         let titleColorSelected: UIColor?
@@ -188,8 +188,7 @@ class Button: UIButton {
         let backgroundImageSelectedHighlighted: UIImage?
         let borderWidth: CGFloat
         let borderColor: UIColor
-        
-        
+
         switch mode {
         case .primary:
             titleColorNormal = theme.primaryButton.textColor.color
@@ -200,7 +199,7 @@ class Button: UIButton {
             backgroundImageHighlighted = theme.primaryButton.backgroundColor.color.darker(by: 10)?.asImage
             backgroundImageSelected = nil
             backgroundImageSelectedHighlighted = nil
-            
+
             borderWidth = 1
             borderColor = theme.primaryButton.borderColor.color
         case .secondary:
@@ -212,7 +211,7 @@ class Button: UIButton {
             backgroundImageHighlighted = theme.secondaryButton.backgroundColor.color.darker(by: 10)?.asImage
             backgroundImageSelected = nil
             backgroundImageSelectedHighlighted = nil
-            
+
             borderWidth = 1
             borderColor = theme.secondaryButton.borderColor.color
         case .scale:
@@ -224,7 +223,7 @@ class Button: UIButton {
             backgroundImageHighlighted = theme.scale.activeBackgroundColor.color.asImage
             backgroundImageSelected = theme.scale.activeBackgroundColor.color.asImage
             backgroundImageSelectedHighlighted = theme.scale.activeBackgroundColor.color.darker(by: 5)?.asImage
-            
+
             borderWidth = 1
             borderColor = theme.scale.inactiveBorderColor.color
         case .button:
@@ -236,11 +235,11 @@ class Button: UIButton {
             backgroundImageHighlighted = theme.button.activeBackgroundColor.color.asImage
             backgroundImageSelected = theme.button.activeBackgroundColor.color.asImage
             backgroundImageSelectedHighlighted = theme.button.inactiveBackgroundColor.color.asImage
-            
+
             borderWidth = 1
             borderColor = theme.button.inactiveBorderColor.color
         }
-        
+
         setTitleColor(titleColorNormal, for: .normal)
         setTitleColor(titleColorHightlighted, for: [.normal, .highlighted])
         setTitleColor(titleColorSelected, for: .selected)
@@ -249,7 +248,7 @@ class Button: UIButton {
         setBackgroundImage(backgroundImageHighlighted, for: [.normal, .highlighted])
         setBackgroundImage(backgroundImageSelected, for: .selected)
         setBackgroundImage(backgroundImageSelectedHighlighted, for: [.selected, .highlighted])
-        
+
         layer.borderWidth = borderWidth
         layer.borderColor = borderColor.cgColor
     }

--- a/delighted/Classes/CES.swift
+++ b/delighted/Classes/CES.swift
@@ -1,21 +1,21 @@
 import UIKit
 
 class CESComponent: UIView, Component {
-    
+
     let configuration: Configuration
     let minLabel: String
     let maxLabel: String
-    
+
     let minNumber: Int
     let maxNumber: Int
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(configuration: Configuration, minLabel: String, maxLabel: String, minNumber: Int, maxNumber: Int, onSelection: @escaping OnSelection) {
         self.configuration = configuration
         self.minLabel = minLabel
@@ -26,34 +26,34 @@ class CESComponent: UIView, Component {
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var buttons: [Button] = {
         var buttons = [Button]()
-        
+
         for i in minNumber...maxNumber {
             let button = Button(configuration: configuration, mode: .scale)
             button.setTitle("\(i)", for: .normal)
             button.titleLabel?.font = configuration.font(ofSize: 16)
             button.isSelected = true
-            
+
             button.addTarget(self, action: #selector(onSelection(sender:)), for: .touchUpInside)
             button.width(constant: 50)
             button.heightEqualWidth()
-            
+
             buttons.append(button)
         }
-        
+
         return buttons
     }()
-    
+
     private lazy var lowerLabel: UILabel = {
         let label = UILabel()
         label.text = minLabel
@@ -63,7 +63,7 @@ class CESComponent: UIView, Component {
         label.textAlignment = .left
         return label
     }()
-    
+
     private lazy var higherLabel: UILabel = {
         let label = UILabel()
         label.text = maxLabel
@@ -73,7 +73,7 @@ class CESComponent: UIView, Component {
         label.textAlignment = .right
         return label
     }()
-    
+
     private func setupView() {
         let component = ViewLayout.createCenterHorizontalStackView(
             subviews: buttons,
@@ -81,14 +81,14 @@ class CESComponent: UIView, Component {
             distribution: maxNumber >= 5 ? .fillEqually : .equalSpacing,
             spacing: 8
         )
-        
+
         let labels = ViewLayout.createCenterHorizontalStackView(subviews: [lowerLabel, higherLabel], alignment: .top, distribution: .equalSpacing, spacing: 12)
-        
+
         let container = ViewLayout.createCenterVerticalStackView(subviews: [component, labels], spacing: 18)
         container.translatesAutoresizingMaskIntoConstraints = false
-        
+
         self.addSubview(container)
-        
+
         // Component should scale full width if there are 5 or more
         // Otherwise component should be tight to the center
         if maxNumber >= 5 {
@@ -109,23 +109,23 @@ class CESComponent: UIView, Component {
             ])
         }
     }
-    
+
     func adjustForFullScreen() {
         lowerLabel.isHidden = true
         higherLabel.isHidden = true
     }
-    
+
     @objc func onSelection(sender: Any?) {
         guard let buttonSelected = sender as? Button else {
             Logger.log(.fatal, "Could not cast selected object as a button")
             return
         }
-        
+
         for button in buttons {
             button.isSelected = false
         }
         buttonSelected.isSelected = true
-        
+
         if let index = buttons.firstIndex(of: buttonSelected) {
             let value = index + minNumber
             onSelection(value)

--- a/delighted/Classes/CSAT.swift
+++ b/delighted/Classes/CSAT.swift
@@ -1,20 +1,20 @@
 import UIKit
 
 class CSATComponent: UIView, Component {
-    
+
     let configuration: Configuration
     let minLabel: String
     let maxLabel: String
     let minNumber: Int
     let maxNumber: Int
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(configuration: Configuration, minLabel: String, maxLabel: String, minNumber: Int, maxNumber: Int, onSelection: @escaping OnSelection) {
         self.configuration = configuration
         self.minLabel = minLabel
@@ -25,34 +25,34 @@ class CSATComponent: UIView, Component {
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var buttons: [Button] = {
         var buttons = [Button]()
-        
+
         for i in minNumber...maxNumber {
             let button = Button(configuration: configuration, mode: .scale)
             button.setTitle("\(i)", for: .normal)
             button.titleLabel?.font = configuration.font(ofSize: 16)
             button.isSelected = true
-            
+
             button.addTarget(self, action: #selector(onSelection(sender:)), for: .touchUpInside)
             button.width(constant: 50)
             button.heightEqualWidth()
-            
+
             buttons.append(button)
         }
-        
+
         return buttons
     }()
-    
+
     private lazy var lowerLabel: UILabel = {
         let label = UILabel()
         label.text = minLabel
@@ -62,7 +62,7 @@ class CSATComponent: UIView, Component {
         label.textAlignment = .left
         return label
     }()
-    
+
     private lazy var higherLabel: UILabel = {
         let label = UILabel()
         label.text = maxLabel
@@ -72,7 +72,7 @@ class CSATComponent: UIView, Component {
         label.textAlignment = .right
         return label
     }()
-    
+
     private func setupView() {
         let component = ViewLayout.createCenterHorizontalStackView(
             subviews: buttons,
@@ -80,14 +80,14 @@ class CSATComponent: UIView, Component {
             distribution: maxNumber >= 5 ? .fillEqually : .equalSpacing,
             spacing: 8
         )
-        
+
         let labels = ViewLayout.createCenterHorizontalStackView(subviews: [lowerLabel, higherLabel], alignment: .top, distribution: .equalSpacing, spacing: 12)
-        
+
         let container = ViewLayout.createCenterVerticalStackView(subviews: [component, labels], spacing: 18)
         container.translatesAutoresizingMaskIntoConstraints = false
-        
+
         self.addSubview(container)
-        
+
         // Component should scale full width if there are 5 or more
         // Otherwise component should be tight to the center
         if maxNumber >= 5 {
@@ -108,18 +108,18 @@ class CSATComponent: UIView, Component {
             ])
         }
     }
-    
+
     func adjustForFullScreen() {
         lowerLabel.isHidden = true
         higherLabel.isHidden = true
     }
-    
+
     @objc func onSelection(sender: Any?) {
         guard let buttonSelected = sender as? Button else {
             Logger.log(.fatal, "Could not cast selected object as a button")
             return
         }
-        
+
         for button in buttons {
             button.isSelected = false
         }

--- a/delighted/Classes/ClientEligibility.swift
+++ b/delighted/Classes/ClientEligibility.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 internal struct ClientEligibility {
-    typealias EligibilityCheckPassed = () -> ()
-    typealias EligibilityCheckFailure = (FailedReason) -> ()
-    
+    typealias EligibilityCheckPassed = () -> Void
+    typealias EligibilityCheckFailure = (FailedReason) -> Void
+
     internal enum FailedReason: Error {
         case cannotGetConfiguration, enabled, exhausted, initialDelay, recurringPeriod, recurringLessThanMinimum, randomSampleFactor(Double), unsupportedDevice, recurringSurveyDisabled
     }
-    
+
     let preSurveySession: PreSurveySession
     init(preSurveySession: PreSurveySession) {
         self.preSurveySession = preSurveySession
@@ -19,26 +19,26 @@ extension ClientEligibility {
     func getDefaults(with eligibilityConfiguration: EligibilityConfiguration) -> UserDefaults? {
         return UserDefaults(suiteName: "Delighted-\(eligibilityConfiguration.surveyContextId)")
     }
-    
+
     func firstSeenDate(defaults: UserDefaults?) -> Date {
         let date = defaults?.object(forKey: "firstSeen") as? Date ?? Date()
         defaults?.set(date, forKey: "firstSeen")
         return date
     }
-    
+
     func setFirstSeenDate(defaults: UserDefaults?, date: Date?) {
         defaults?.set(date, forKey: "firstSeen")
     }
-    
+
     func lastSurveyedDate(defaults: UserDefaults?) -> Date? {
         return defaults?.object(forKey: "lastSurveyed") as? Date
     }
-    
+
     func setLastSurveyedDate(defaults: UserDefaults?, date: Date?) {
         defaults?.set(date, forKey: "lastSurveyed")
     }
 }
-    
+
 extension ClientEligibility {
     func check(
         with overrides: EligibilityOverrides? = nil,
@@ -49,13 +49,13 @@ extension ClientEligibility {
             failure(.unsupportedDevice)
             return
         }
-        
+
         // Pass right away if developer is testing
         if let isTest = overrides?.testMode, isTest {
             passed()
             return
         }
-        
+
         // Fetch eligibility configuration
         let route = Route.eligibilityConfiguration
         preSurveySession.sendRequest(route: route, completion: { (data, _) in
@@ -64,21 +64,21 @@ extension ClientEligibility {
                     failure(.cannotGetConfiguration)
                     return
                 }
-                
+
                 do {
                     let decoder = JSONDecoder()
                     decoder.keyDecodingStrategy = .convertFromSnakeCase
-                    
+
                     // Apply developer overrides on top of configuration from API
                     var eligibilityConfiguration = try decoder.decode(EligibilityConfiguration.self, from: data)
                     eligibilityConfiguration.apply(overrides: overrides)
-                    
+
                     // Perform client side eligibility checks now
                     self.doClientSideCheck(overrides: overrides, eligibilityConfiguration: eligibilityConfiguration, passed: { () in
                         // Set last surveyed and then continue on with the passing
                         let defaults = self.getDefaults(with: eligibilityConfiguration)
                         self.setLastSurveyedDate(defaults: defaults, date: Date())
-                        
+
                         passed()
                     }, failure: failure)
                 } catch {
@@ -97,11 +97,11 @@ extension ClientEligibility {
 
 internal extension ClientEligibility {
     static let iPhoneMinHeight: CGFloat = 667.0 // iPhone 6 and newer screen sizes
-    
+
     func isDeviceSupported() -> Bool {
         return UIDevice.current.userInterfaceIdiom == .phone && UIScreen.main.bounds.height >= ClientEligibility.iPhoneMinHeight
     }
-    
+
     func doClientSideCheck(overrides: EligibilityOverrides? = nil, eligibilityConfiguration: EligibilityConfiguration, passed: @escaping EligibilityCheckPassed, failure: @escaping EligibilityCheckFailure) {
 
         // Fail if not enabled
@@ -109,19 +109,19 @@ internal extension ClientEligibility {
             failure(.enabled)
             return
         }
-        
+
         // Fail if plan exhausted
         if eligibilityConfiguration.planLimitExhausted {
             failure(.exhausted)
             return
         }
-        
+
         // Skip checking if force display
         if !eligibilityConfiguration.forceDisplay {
-            
+
             // Getting defaults object to get cached data
             let defaults = self.getDefaults(with: eligibilityConfiguration)
-            
+
             // Skip checking if no created at or last surveyed
             if let lastSurveyed = self.lastSurveyedDate(defaults: defaults) {
                 // Fail when a person has been surveyed but recurring surveys aren't enabled
@@ -136,7 +136,7 @@ internal extension ClientEligibility {
                     failure(.recurringPeriod)
                     return
                 }
-                
+
                 // Fail if recurring period less than minimum survey interval
                 // Note: this will only ever fail if developer override caused this to happen
                 if eligibilityConfiguration.recurringSurveyPeriod! < eligibilityConfiguration.minSurveyInterval {
@@ -145,7 +145,7 @@ internal extension ClientEligibility {
                 }
             } else if let initialSurveyDelay = eligibilityConfiguration.initialSurveyDelay {
                 let createdAtOrLastSurveyedAt = overrides?.createdAt ?? firstSeenDate(defaults: defaults)
-                
+
                 // Fail if last surveyed is less than initial delay.
                 let delay = TimeInterval(initialSurveyDelay)
                 if createdAtOrLastSurveyedAt.addingTimeInterval(delay) >= Date() {
@@ -154,12 +154,12 @@ internal extension ClientEligibility {
                 }
             }
         }
-        
+
         self.doRandomSampleFactor(sampleFactor: eligibilityConfiguration.sampleFactor, passed: passed, failure: failure)
     }
-    
+
     func doRandomSampleFactor(sampleFactor: Float, passed: EligibilityCheckPassed, failure: @escaping EligibilityCheckFailure) {
-        
+
         // Pass if random number is less than the sample factor
         let random = drand48()
         if random <= Double(sampleFactor) {

--- a/delighted/Classes/ClientEligibility.swift
+++ b/delighted/Classes/ClientEligibility.swift
@@ -86,12 +86,12 @@ extension ClientEligibility {
                     Logger.log(.error, "Could not decode eligibility configuration request")
                 }
             }
-        }) { (error) in
+        }, failure: { (error) in
             DispatchQueue.main.async {
                 Logger.log(.error, "Could not complete eligibility configuration request \(error.localizedDescription)")
                 failure(.cannotGetConfiguration)
             }
-        }
+        })
     }
 }
 

--- a/delighted/Classes/CloseButton.swift
+++ b/delighted/Classes/CloseButton.swift
@@ -1,29 +1,29 @@
 import UIKit
 
 class CloseButton: UIButton {
-    
+
     let theme: Theme
-    
+
     lazy var xImageView: UIImageView = {
         let imageView = UIImageView(image: Images.x.templateImage)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.tintColor = theme.closeButton.normalTextColor.color
-        
+
         return imageView
     }()
-    
+
     lazy var circleView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = theme.closeButton.normalBackgroundColor.color
-        
+
         view.layer.masksToBounds = false
         view.layer.cornerRadius = 12
         view.layer.borderColor = theme.closeButton.normalBorderColor.color.cgColor
         view.layer.borderWidth = 2
-        
+
         view.isUserInteractionEnabled = false
-        
+
         return view
     }()
 
@@ -33,18 +33,18 @@ class CloseButton: UIButton {
             updateTint()
         }
     }
-    
+
     init(theme: Theme) {
         self.theme = theme
         super.init(frame: .zero)
         setupView()
         updateTint()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func updateTint() {
         switch isHighlighted {
         case false:
@@ -57,17 +57,17 @@ class CloseButton: UIButton {
             circleView.layer.borderColor = theme.closeButton.highlightedBorderColor.color.cgColor
         }
     }
-    
+
     func setupView() {
         addSubview(circleView)
         addSubview(xImageView)
-        
+
         NSLayoutConstraint.activate([
             circleView.centerXAnchor.constraint(equalTo: centerXAnchor),
             circleView.centerYAnchor.constraint(equalTo: centerYAnchor),
             circleView.widthAnchor.constraint(equalToConstant: 24),
             circleView.heightAnchor.constraint(equalToConstant: 24),
-            
+
             xImageView.centerXAnchor.constraint(equalTo: circleView.centerXAnchor),
             xImageView.centerYAnchor.constraint(equalTo: circleView.centerYAnchor),
             xImageView.widthAnchor.constraint(equalToConstant: 10),

--- a/delighted/Classes/Colors.swift
+++ b/delighted/Classes/Colors.swift
@@ -35,7 +35,7 @@ extension UIColor {
     func darker(by percentage: CGFloat = 30.0) -> UIColor? {
         return self.adjust(by: -1 * abs(percentage) )
     }
-    
+
     func adjust(by percentage: CGFloat = 30.0) -> UIColor? {
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
         if self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
@@ -47,7 +47,7 @@ extension UIColor {
             return nil
         }
     }
-    
+
     var asImage: UIImage? {
         let rect = CGRect(x: 0, y: 0, width: 1, height: 1)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, 0)

--- a/delighted/Classes/Component.swift
+++ b/delighted/Classes/Component.swift
@@ -7,10 +7,10 @@ protocol Component where Self: UIView {
 
 extension Component {
     func adjustForInitialDisplay() {
-        
+
     }
-    
+
     func adjustForFullScreen() {
-        
+
     }
 }

--- a/delighted/Classes/Configuration.swift
+++ b/delighted/Classes/Configuration.swift
@@ -19,31 +19,31 @@ public enum ThemeShape: String, Decodable {
 public class Options: NSObject {
     // From API
     var textBaseDirection: TextBaseDirection?
-    
+
     var poweredByLinkText: String?
     var poweredByLinkURL: String?
-    
+
     var nextText: String?
     var prevText: String?
-    
+
     var selectOneText: String?
     var selectManyText: String?
-    
+
     var submitText: String?
     var doneText: String?
-    
+
     var notLikelyText: String?
     var veryLikelyText: String?
-    
+
     var theme: Theme?
-    
+
     // From developer
     var modalMargin: CGFloat
     var baseURL: URL?
     var cdnURL: URL?
     var fontFamilyName: String?
     var thankYouAutoCloseDelay: Int?
-    
+
     public init(
         textBaseDirection: TextBaseDirection? = nil,
         poweredByLinkText: String? = nil,
@@ -76,7 +76,7 @@ public class Options: NSObject {
         self.notLikelyText = notLikelyText
         self.veryLikelyText = veryLikelyText
         self.theme = theme
-        
+
         // From developer
         self.modalMargin = modalMargin
         self.baseURL = baseURL
@@ -88,29 +88,29 @@ public class Options: NSObject {
 
 public struct Configuration {
     static let cornerRadius: CGFloat = 8.0
-    
+
     // From API
     var textBaseDirection: TextBaseDirection
-    
+
     var poweredByLinkText: String
     var poweredByLinkURL: String
-    
+
     var nextText: String
     var prevText: String
-    
+
     var selectOneText: String
     var selectManyText: String
-    
+
     var submitText: String
     var doneText: String
-    
+
     var notLikelyText: String
     var veryLikelyText: String
-    
+
     let pusher: Pusher
-    
+
     var theme: Theme
-    
+
     // From developer
     var display: Display = .card
     var modalMargin: CGFloat = 10
@@ -118,30 +118,30 @@ public struct Configuration {
     var cdnURL: URL?
     var fontFamilyName: String = UIFont.systemFont(ofSize: 1).familyName
     var thankYouAutoCloseDelay: Int?
-    
+
     mutating func applyOptions(options: Options?) {
         guard let options = options else { return }
 
         // From API
         textBaseDirection = options.textBaseDirection ?? textBaseDirection
-        
+
         poweredByLinkText = options.poweredByLinkText ?? poweredByLinkText
         poweredByLinkURL = options.poweredByLinkURL ?? poweredByLinkURL
-        
+
         nextText = options.nextText ?? nextText
         prevText = options.prevText ?? prevText
-        
+
         selectOneText = options.selectOneText ?? selectOneText
         selectManyText = options.selectManyText ?? selectManyText
-        
+
         submitText = options.submitText ?? submitText
         doneText = options.doneText ?? doneText
 
         notLikelyText = options.notLikelyText ?? notLikelyText
         veryLikelyText = options.veryLikelyText ?? veryLikelyText
-        
+
         self.theme = options.theme ?? theme
-        
+
         // From developer
         self.modalMargin = options.modalMargin
         self.baseURL = options.baseURL ?? baseURL
@@ -149,7 +149,7 @@ public struct Configuration {
         self.fontFamilyName = options.fontFamilyName ?? fontFamilyName
         self.thankYouAutoCloseDelay = options.thankYouAutoCloseDelay
     }
-    
+
     struct Pusher: Decodable {
         let webSocketUrl: String?
         let channelName: String?
@@ -166,28 +166,28 @@ extension Configuration: Decodable {
         themeColorPrimary, themeColorStars, themeStyle, themeShape,
         theme
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.textBaseDirection = try container.decode(TextBaseDirection.self, forKey: .textBaseDirection)
-        
+
         self.poweredByLinkText = try container.decode(String.self, forKey: .poweredByLinkText)
         self.poweredByLinkURL = try container.decode(String.self, forKey: .poweredByLinkUrl)
-        
+
         self.nextText = try container.decode(String.self, forKey: .nextText)
         self.prevText = try container.decode(String.self, forKey: .prevText)
-        
+
         self.selectOneText = try container.decode(String.self, forKey: .selectOneText)
         self.selectManyText = try container.decode(String.self, forKey: .selectManyText)
-        
+
         self.submitText = try container.decode(String.self, forKey: .submitText)
         self.doneText = try container.decode(String.self, forKey: .doneText)
-        
+
         self.notLikelyText = try container.decode(String.self, forKey: .notLikelyText)
         self.veryLikelyText = try container.decode(String.self, forKey: .veryLikelyText)
-        
+
         self.pusher = try container.decode(Pusher.self, forKey: .pusher)
-  
+
         self.theme = try container.decode(Theme.self, forKey: .theme)
     }
 }

--- a/delighted/Classes/Delighted.swift
+++ b/delighted/Classes/Delighted.swift
@@ -107,11 +107,11 @@ import UIKit
                 testMode: eligibilityOverrides?.testMode,
                 inViewController: userViewController
             )
-        }) { (failedReason) in
+        }, whenIneligible: { (failedReason) in
             Logger.log(.debug, "Failed client side eligibility at step \(failedReason)")
             Delighted.surveying = false
             callback?(.failedClientEligibility(failedReason))
-        }
+        })
     }
 
     public static func hide(completion: (() -> Void)? = nil) {
@@ -165,12 +165,12 @@ import UIKit
                     Logger.log(.error, "Could not decode survey request \(error)")
                 }
             }
-        }) { (error) in
+        }, failure: { (error) in
             DispatchQueue.main.async {
                 Delighted.surveying = false
                 preSurveySession.callback?(.error(error))
             }
-        }
+        })
     }
 
     private static func showSurvey(
@@ -182,7 +182,7 @@ import UIKit
 
         // Finds window and root view controller for presenting
         // TOOD: look into iOS 13 weirdness
-        guard let _ = userViewController ?? UIApplication.shared.keyWindow?.rootViewController else {
+        guard (userViewController ?? UIApplication.shared.keyWindow?.rootViewController) != nil else {
             Logger.log(.fatal, "No window or root view controller to present on")
             return
         }

--- a/delighted/Classes/Delighted.swift
+++ b/delighted/Classes/Delighted.swift
@@ -9,22 +9,22 @@ import UIKit
 }
 
 @objc public class Delighted: NSObject {
-    
+
     /// New window that the survey will be displayed in
     internal static var window: UIWindow?
-    
+
     internal static var surveying = false
-    
+
     @objc public static weak var delegate: DelightedDelegate?
-    
-    public typealias SurveyCallback = (Status) -> ()
-    
+
+    public typealias SurveyCallback = (Status) -> Void
+
     public enum Status {
         case failedClientEligibility(Error)
         case error(Error)
         case surveyClosed(DelightedSurveyResponseStatus)
     }
-    
+
     public static var logLevel: Logger {
         get {
             return Logger.level
@@ -33,12 +33,12 @@ import UIKit
             Logger.level = newValue
         }
     }
-    
+
     @objc public static func initializeSDK() {
         Logger.log(.info, "init")
         RequestCache.retryAll()
     }
-    
+
     @objc public static func survey(
         delightedID: String,
         token: String? = nil,
@@ -68,7 +68,7 @@ import UIKit
                 }
         })
     }
-    
+
     public static func survey(
         delightedID: String,
         token: String? = nil,
@@ -78,24 +78,24 @@ import UIKit
         eligibilityOverrides: EligibilityOverrides? = nil,
         inViewController userViewController: UIViewController? = nil,
         callback: SurveyCallback? = nil) {
-        
+
         // Retry sending all failed requests
         RequestCache.retryAll()
-        
+
         // Only display if another survey is not being displayed
         guard !Delighted.surveying else {
             Logger.log(.warn, "Cannot request survey - another survey window is already open")
             return
         }
         Delighted.surveying = true
-        
+
         let preSurveySession = PreSurveySession(
             delightedID: delightedID,
             baseURL: options?.baseURL,
             cdnURL: options?.cdnURL,
             callback: callback
         )
-        
+
         ClientEligibility.init(preSurveySession: preSurveySession).check(with: eligibilityOverrides, whenEligible: {
             Logger.log(.debug, "Passed client side eligibility")
             sendRequestSurvey(
@@ -113,7 +113,7 @@ import UIKit
             callback?(.failedClientEligibility(failedReason))
         }
     }
-    
+
     public static func hide(completion: (() -> Void)? = nil) {
         if let root = window?.rootViewController, let delightedPageViewController = root as? DelightedPageViewController {
             delightedPageViewController.surveyViewController.hide {
@@ -121,7 +121,7 @@ import UIKit
             }
         }
     }
-    
+
     private static func sendRequestSurvey(
         preSurveySession: PreSurveySession,
         token: String? = nil,
@@ -130,7 +130,7 @@ import UIKit
         options: Options? = nil,
         testMode: Bool?,
         inViewController userViewController: UIViewController? = nil) {
-        
+
         // Survey request body
         let surveyRequestBody = SurveyRequestBody(
             token: token,
@@ -138,23 +138,23 @@ import UIKit
             properties: properties,
             testMode: testMode
         )
-        
+
         // Send survey request
         let route = Route.surveyRequest(surveyRequestBody: surveyRequestBody)
-        preSurveySession.sendRequest(route: route, completion: { (data, response) in
+        preSurveySession.sendRequest(route: route, completion: { (data, _) in
             DispatchQueue.main.async {
                 guard let data = data else {
                     Delighted.surveying = false
                     preSurveySession.callback?(.error(APIError.noResponse))
                     return
                 }
-                
+
                 do {
                     let decoder = JSONDecoder()
                     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
                     let surveyRequest = try decoder.decode(SurveyRequest.self, from: data)
-                    
+
                     var configuration = surveyRequest.survey.configuration
                     configuration.applyOptions(options: options)
 
@@ -172,26 +172,26 @@ import UIKit
             }
         }
     }
-    
+
     private static func showSurvey(
         preSurveySession: PreSurveySession,
         surveyRequest: SurveyRequest,
         configuration: Configuration,
         inViewController userViewController: UIViewController? = nil
         ) {
-        
+
         // Finds window and root view controller for presenting
         // TOOD: look into iOS 13 weirdness
         guard let _ = userViewController ?? UIApplication.shared.keyWindow?.rootViewController else {
             Logger.log(.fatal, "No window or root view controller to present on")
             return
         }
-        
+
         let surveyResponse = SurveyResponse(
             delightedID: preSurveySession.delightedID,
             surveyRequestToken: surveyRequest.token
         )
-        
+
         let session = SurveySession(
             preSurveySession: preSurveySession,
             surveyRequest: surveyRequest,
@@ -199,7 +199,7 @@ import UIKit
             configuration: configuration
         )
         session.connectPusher()
-        
+
         let window: UIWindow = {
             // Need to check if UIScene in iOS 13 and higher
             // If yes, then create a window with the scene
@@ -209,27 +209,27 @@ import UIKit
                     .connectedScenes
                     .filter { $0.activationState == .foregroundActive }
                     .first
-                
+
                 if let windowScene = windowScene as? UIWindowScene {
                     return UIWindow(windowScene: windowScene)
                 }
             }
-            
+
             return UIWindow(frame: UIScreen.main.bounds)
         }()
-        
+
         // Making a new window for navigation controller
         // This is needed so that Delighted can force portrait
         window.windowLevel = .normal
         window.isHidden = false
         window.makeKeyAndVisible()
         window.backgroundColor = Colors.clear
-        
+
         Delighted.window = window
-        
+
         // Sets up transparent navigation controller to lay over current context
         let navigationController = DelightedPageViewController(session: session)
-        
+
         navigationController.view.backgroundColor = Colors.clear
         navigationController.modalPresentationStyle = .overCurrentContext
         navigationController.modalTransitionStyle = .coverVertical
@@ -240,9 +240,9 @@ import UIKit
 
 public enum Logger: Int {
     case off, fatal, error, warn, info, debug
-    
+
     static var level = Logger.error
-    
+
     var label: String {
         switch self {
         case .off:
@@ -259,7 +259,7 @@ public enum Logger: Int {
             return "DEBUG"
         }
     }
-    
+
     static func log(_ logger: Logger, _ message: String) {
         guard logger != .off && logger.rawValue <= Logger.level.rawValue else { return }
         print("Delighted::\(logger.label) - \(message)")

--- a/delighted/Classes/DelightedPageViewController.swift
+++ b/delighted/Classes/DelightedPageViewController.swift
@@ -142,12 +142,12 @@ class DelightedPageViewController: UIPageViewController {
 
             UIView.animate(withDuration: 0.35, animations: {
                 window.frame = newFrame
-            }) { (_) in
+            }, completion: { (_) in
                 // Releases the window
                 Delighted.window = nil
                 Delighted.surveying = false
                 completion?()
-            }
+            })
         } else {
             // Releases the window
             Delighted.window = nil

--- a/delighted/Classes/DelightedPageViewController.swift
+++ b/delighted/Classes/DelightedPageViewController.swift
@@ -10,18 +10,18 @@ class DelightedPageViewController: UIPageViewController {
     enum State {
         case survey, additionalQuestions, thankYou
     }
-    
+
     let session: SurveySession
     var state: State {
         didSet {
             updateViewController()
         }
     }
-    
+
     override var prefersStatusBarHidden: Bool {
         return session.configuration.theme.ios.statusBarHidden ?? false
     }
-    
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         switch session.configuration.theme.ios.statusBarMode {
         case .darkContent?:
@@ -36,16 +36,16 @@ class DelightedPageViewController: UIPageViewController {
             return .default
         }
     }
-    
+
     lazy var surveyViewController: SurveyViewController = {
        return SurveyViewController(pageViewController: self, session: session)
     }()
-    
+
     lazy var additionalQuestionViewControllers: [UIViewController] = {
         let surveyGroup = session.surveyRequest.survey.type.groups.first(where: { (group) -> Bool in
             return group.scoreMin...group.scoreMax ~= session.surveyResponse.score!
         })
-        
+
         let additionalQuestions = session.surveyRequest.survey.template.additionalQuestions.filter({ question in
             guard let targetAudienceGroups = question.targetAudienceGroups else {
                 return true
@@ -55,7 +55,7 @@ class DelightedPageViewController: UIPageViewController {
             }
             return targetAudienceGroups.contains(targetGroup.name)
         })
-        
+
         let viewControllers = additionalQuestions.enumerated().map({ (arg) -> AdditionalQuestionViewController in
             let (index, question) = arg
             return AdditionalQuestionViewController(
@@ -66,45 +66,45 @@ class DelightedPageViewController: UIPageViewController {
                 isLastQuestion: index == (additionalQuestions.count - 1)
             )
         })
-        
+
         return viewControllers
     }()
-    
+
     lazy var thankYouViewController: ThankYouViewController = {
         return ThankYouViewController(
             pageViewController: self,
             session: session
         )
     }()
-    
+
     init(session: SurveySession) {
         self.session = session
         self.state = .survey
-        
+
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
-        
+
         self.setViewControllers([surveyViewController], direction: .forward, animated: false)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
     }
-    
+
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return .portrait
     }
-    
+
     override var shouldAutorotate: Bool {
         return true
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         let edgePanLeft = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(screenLeftEdgeSwiped))
         edgePanLeft.edges = .left
         let edgePanRight = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(screenRightEdgeSwiped))
@@ -113,24 +113,24 @@ class DelightedPageViewController: UIPageViewController {
         view.addGestureRecognizer(edgePanLeft)
         view.addGestureRecognizer(edgePanRight)
     }
-    
+
     @objc func screenLeftEdgeSwiped(_ recognizer: UIScreenEdgePanGestureRecognizer) {
         if recognizer.state == .recognized {
             previousPage()
         }
     }
-    
+
     @objc func screenRightEdgeSwiped(_ recognizer: UIScreenEdgePanGestureRecognizer) {
         if recognizer.state == .recognized {
             nextPage()
         }
     }
-    
+
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         guard let window = Delighted.window else {
             return
         }
-        
+
         if flag {
             // Animates the
             let windowFrame = window.frame
@@ -139,7 +139,7 @@ class DelightedPageViewController: UIPageViewController {
                 y: windowFrame.maxY,
                 width: windowFrame.width,
                 height: windowFrame.height)
-            
+
             UIView.animate(withDuration: 0.35, animations: {
                 window.frame = newFrame
             }) { (_) in
@@ -175,13 +175,13 @@ private extension DelightedPageViewController {
         }
     }
 }
-    
+
 extension DelightedPageViewController {
     func previousPage() {
         guard let viewController = viewControllers?.first else {
             return
         }
-        
+
         switch state {
         case .survey, .thankYou:
             return
@@ -189,19 +189,19 @@ extension DelightedPageViewController {
             guard let index = additionalQuestionViewControllers.firstIndex(of: viewController), index > 0 else {
                 return
             }
-            
+
             let previousViewController = additionalQuestionViewControllers[index - 1]
             self.setViewControllers([previousViewController], direction: .reverse, animated: true)
-            
+
             return
         }
     }
-    
+
     func nextPage() {
         guard let viewController = viewControllers?.first else {
             return
         }
-        
+
         switch state {
         case .survey, .thankYou:
             return
@@ -209,10 +209,10 @@ extension DelightedPageViewController {
             guard let index = additionalQuestionViewControllers.firstIndex(of: viewController), index < (additionalQuestionViewControllers.count - 1) else {
                 return
             }
-            
+
             let previousViewController = additionalQuestionViewControllers[index + 1]
             self.setViewControllers([previousViewController], direction: .forward, animated: true)
-            
+
             return
         }
     }

--- a/delighted/Classes/EligibilityConfiguration.swift
+++ b/delighted/Classes/EligibilityConfiguration.swift
@@ -12,7 +12,7 @@ struct EligibilityConfiguration {
 }
 
 extension EligibilityConfiguration: Decodable {
-    
+
 }
 
 extension EligibilityConfiguration {
@@ -24,7 +24,7 @@ extension EligibilityConfiguration {
         if let recurringPeriod = overrides?.recurringPeriod {
             self.recurringSurveyPeriod = recurringPeriod
         }
-        
+
         return self
     }
 }
@@ -34,14 +34,14 @@ extension EligibilityConfiguration {
     public let createdAt: Date?
     public let initialDelay: Int?
     public let recurringPeriod: Int?
-    
+
     @objc public init(testMode: Bool = false, createdAt: Date? = nil) {
         self.testMode = testMode
         self.createdAt = createdAt
         self.initialDelay = nil
         self.recurringPeriod = nil
     }
-    
+
     public init(testMode: Bool = false, createdAt: Date? = nil, initialDelay: Int? = nil, recurringPeriod: Int? = nil) {
         self.testMode = testMode
         self.createdAt = createdAt

--- a/delighted/Classes/Haptic.swift
+++ b/delighted/Classes/Haptic.swift
@@ -17,7 +17,7 @@ extension Haptic {
                     return .heavy
                 }
             }
-            
+
             let generator = UIImpactFeedbackGenerator(style: style)
             generator.impactOccurred()
         }

--- a/delighted/Classes/Images.swift
+++ b/delighted/Classes/Images.swift
@@ -1,34 +1,34 @@
 import UIKit
 
 enum Images: String {
-    
+
     case check = "check"
-    
+
     case x = "x"
     case close = "close"
     case star = "star"
     case starOutline = "star_outline"
-    
+
     case smileyVeryUnhappy = "smilies_very_unhappy"
     case smileyUnhappy = "smilies_unhappy"
     case smileyNeutral = "smilies_neutral"
     case smileyHappy = "smilies_happy"
     case smileyVeryHappy = "smilies_very_happy"
-    
+
     case thumbsUp = "thumbs_up"
     case thumbsDown = "thumbs_down"
-    
+
     var image: UIImage? {
         let bundle = Bundle(for: ImagesClassForBundle.self)
         let image = UIImage(named: rawValue, in: bundle, compatibleWith: nil)
         return image
     }
-    
+
     var templateImage: UIImage? {
         return image?.withRenderingMode(.alwaysTemplate)
     }
 }
 
 private class ImagesClassForBundle {
-    
+
 }

--- a/delighted/Classes/NPS.swift
+++ b/delighted/Classes/NPS.swift
@@ -205,9 +205,9 @@ class NPSComponent: UIView, Component {
             self.setThumbConstant(self.trackView.frame.width * percent)
             self.setNeedsLayout()
             self.layoutIfNeeded()
-        }) { (_) in
+        }, completion: { (_) in
             finished?()
-        }
+        })
 
         // Determine if  stepping up or down in the stride
         let isSteppingUp = startingWholeNumber < Int(self.lastWholeNumber)
@@ -421,12 +421,12 @@ extension NPSComponent {
 
             self.setNeedsLayout()
             self.layoutIfNeeded()
-        }) { [unowned self] finished in
+        }, completion: { [unowned self] finished in
             self.thumbViewLabel.isHidden = hideLabel
             if finished {
                 completion?()
             }
-        }
+        })
     }
 
     func handleTouchBegin() {

--- a/delighted/Classes/OptionSelect.swift
+++ b/delighted/Classes/OptionSelect.swift
@@ -4,20 +4,20 @@ class OptionSelect: UIView {
     let configuration: Configuration
     let question: Survey.Template.AdditionalQuestion
     let mode: Mode
-    
+
     var buttons: [UIButton] = []
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
-    typealias OnSelection = ([Survey.Template.AdditionalQuestion.Option]) -> ()
+
+    typealias OnSelection = ([Survey.Template.AdditionalQuestion.Option]) -> Void
     let onSelection: OnSelection
-    
+
     enum Mode {
         case single, multi
     }
-    
+
     init(configuration: Configuration, question: Survey.Template.AdditionalQuestion, mode: Mode, onSelection: @escaping OnSelection) {
         self.configuration = configuration
         self.question = question
@@ -26,94 +26,94 @@ class OptionSelect: UIView {
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var scrollView: UIView = {
         let view = UIScrollView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.showsVerticalScrollIndicator = false
         return view
     }()
-    
+
     private lazy var directionsLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        
+
         switch mode {
         case .single:
             label.text = configuration.selectOneText
         case .multi:
             label.text = configuration.selectManyText
         }
-        
+
         label.textColor = theme.secondaryTextColor.color
         label.font = configuration.font(ofSize: 16)
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
     }()
-    
+
     private func setupView() {
         let options = question.options ?? []
         for option in options {
             buttons.append(makeButton(title: option.text))
         }
-        
+
         let component = ViewLayout.createCenterVerticalStackView(subviews: buttons, spacing: 10)
         component.translatesAutoresizingMaskIntoConstraints = false
-        
+
         self.addSubview(directionsLabel)
         self.addSubview(scrollView)
         scrollView.addSubview(component)
-        
+
         NSLayoutConstraint.activate([
             directionsLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             directionsLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             directionsLabel.topAnchor.constraint(equalTo: self.topAnchor),
-            
+
             scrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: directionsLabel.bottomAnchor, constant: 10),
             scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            
+
             scrollView.topAnchor.constraint(equalTo: component.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: component.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: component.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: component.bottomAnchor),
-            
+
             scrollView.widthAnchor.constraint(equalTo: self.widthAnchor),
             component.widthAnchor.constraint(equalTo: self.widthAnchor)
         ])
-        
+
         buttons.forEach { (button) in
             button.heightAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
         }
     }
-    
+
     private func makeButton(title: String) -> Button {
         let button = Button(configuration: configuration, mode: .button)
         button.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.setTitle(title, for: .normal)
-        
+
         button.setImage(nil, for: .normal)
         button.setImage(Images.check.templateImage, for: .selected)
         button.imageView?.contentMode = .scaleAspectFit
         button.tintColor = theme.button.activeTextColor.color
-        
+
         button.translatesAutoresizingMaskIntoConstraints = false
         button.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
         button.imageView?.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.titleLabel?.centerYAnchor.constraint(equalTo: button.centerYAnchor).isActive = true
-        
+
         // Adjusts content edge insets to allow for the checkmark image to not overlap with the title
         button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 50, bottom: 8, right: 50)
 
@@ -121,20 +121,20 @@ class OptionSelect: UIView {
         button.imageView?.centerYAnchor.constraint(equalTo: button.centerYAnchor, constant: 0.0).isActive = true
         button.imageView?.heightAnchor.constraint(equalToConstant: 20).isActive = true
         button.imageView?.widthAnchor.constraint(equalToConstant: 20).isActive = true
-        
+
         button.titleLabel?.trailingAnchor.constraint(lessThanOrEqualTo: button.imageView!.leadingAnchor, constant: -10).isActive = true
         button.titleLabel?.textAlignment = .center
-        
+
         switch mode {
         case .single:
             button.addTarget(self, action: #selector(onSelectSingle(sender:)), for: .touchUpInside)
         case .multi:
             button.addTarget(self, action: #selector(onSelectMulti(sender:)), for: .touchUpInside)
         }
-        
+
         return button
     }
-    
+
     private func callbackSelected() {
         let options = buttons.filter { (button) -> Bool in
             return button.isSelected
@@ -143,15 +143,15 @@ class OptionSelect: UIView {
         }.compactMap { (index) -> Survey.Template.AdditionalQuestion.Option? in
             return question.options?[index]
         }
-        
+
         onSelection(options)
     }
-    
+
     @objc func onSelectSingle(sender: Any?) {
         guard let button = sender as? UIButton else {
             return
         }
-        
+
         UIView.transition(with: button, duration: 0.2, options: .transitionCrossDissolve, animations: { [unowned self] in
             self.buttons.forEach { (button) in
                 button.isSelected = false
@@ -161,12 +161,12 @@ class OptionSelect: UIView {
             self.callbackSelected()
         })
     }
-    
+
     @objc func onSelectMulti(sender: Any?) {
         guard let button = sender as? UIButton else {
             return
         }
-        
+
         UIView.transition(with: button, duration: 0.2, options: .transitionCrossDissolve, animations: {
             button.isSelected = !button.isSelected
         }, completion: { [unowned self] (_) in
@@ -174,4 +174,3 @@ class OptionSelect: UIView {
         })
     }
 }
-

--- a/delighted/Classes/Person.swift
+++ b/delighted/Classes/Person.swift
@@ -4,7 +4,7 @@ import Foundation
     let name: String?
     let email: String?
     let phoneNumber: String?
-    
+
     @objc public init(name: String? = nil, email: String? = nil, phoneNumber: String? = nil) {
         self.name = name
         self.email = email

--- a/delighted/Classes/PoweredBy.swift
+++ b/delighted/Classes/PoweredBy.swift
@@ -31,7 +31,7 @@ class PoweredBy: UIButton {
     
     @objc func onTap() {
         if let url = URL(string: configuration.poweredByLinkURL), UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.openURL(url)
+            UIApplication.shared.open(url, options: [:])
         }
     }
 }

--- a/delighted/Classes/PoweredBy.swift
+++ b/delighted/Classes/PoweredBy.swift
@@ -1,23 +1,23 @@
 import UIKit
 
 class PoweredBy: UIButton {
-    
+
     let configuration: Configuration
-    
+
     init(configuration: Configuration) {
         self.configuration = configuration
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
         setTitle(configuration.poweredByLinkText, for: .normal)
@@ -25,10 +25,10 @@ class PoweredBy: UIButton {
         titleLabel?.numberOfLines = 1
         titleLabel?.textAlignment = .center
         titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .light)
-        
+
         addTarget(self, action: #selector(onTap), for: .touchUpInside)
     }
-    
+
     @objc func onTap() {
         if let url = URL(string: configuration.poweredByLinkURL), UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url, options: [:])

--- a/delighted/Classes/Pusher.swift
+++ b/delighted/Classes/Pusher.swift
@@ -30,11 +30,11 @@ class Pusher {
     let channelName: String
     let surveyRequestToken: String
     let socket: WebSocket
-    
+
     var subscribed = false
     var clientTypingLastSent: Date?
     var numberOfClientTypingsSent = 0
-    
+
     public init(websocketURL: URL, baseAPIURL: URL, channelName: String, surveyRequestToken: String) {
         self.websocketURL = websocketURL
         self.baseAPIURL = baseAPIURL
@@ -49,37 +49,37 @@ extension Pusher {
     public func connect() {
         socket.connect()
     }
-    
+
     public func disconnect() {
         subscribed = false
         socket.disconnect()
     }
-    
+
     func sendClientTyping() {
         // ONly send events when subscribed
         guard subscribed else {
             Logger.log(.error, "Can't send event to pusher - not subsubscribed")
             return
         }
-        
+
         // Only low max of 1000 events
         guard self.numberOfClientTypingsSent < 1000 else {
             Logger.log(.debug, "Sent over 1000 pusher client typing events")
             return
         }
-        
+
         // Prevent sending events within 2 seconds of each other
         guard (clientTypingLastSent ?? Date.distantPast).timeIntervalSinceNow < -2 else {
             Logger.log(.debug, "Can't send event to pusher - need to wait 2 seconds")
             return
         }
-        
+
         // Sets last typing to now
         // Increments number of events sent
         // Encoding event to write to socket
         self.clientTypingLastSent = Date()
         self.numberOfClientTypingsSent = self.numberOfClientTypingsSent + 1
-        
+
         let event = Event(event: .clientTyping, channel: self.channelName, data: [
             "survey_request_token": self.surveyRequestToken
             ])
@@ -109,7 +109,7 @@ private extension Pusher {
             break
         }
     }
-    
+
     func authorize(socketId: String) {
         // Create pusher auth body
         let pusherAuthBody = PusherAuthRequest(
@@ -117,16 +117,16 @@ private extension Pusher {
             socketId: socketId,
             channelName: self.channelName
         )
-        
+
         // Sends request to get pusher auth
         let route = Route.pusherAuth(pusherAuthRequest: pusherAuthBody)
         let request = try? Request(baseURL: baseAPIURL, route: route)
-        request?.send(completion: { [weak self] (data, response) in
+        request?.send(completion: { [weak self] (data, _) in
             guard let data = data else {
                 Logger.log(.error, "No data received from push auth response")
                 return
             }
-            
+
             // Decodes with PusherAuthResponse
             do {
                 let pusherAuthResponse = try decoder.decode(PusherAuthResponse.self, from: data)
@@ -138,13 +138,13 @@ private extension Pusher {
             Logger.log(.error, "Error sending push auth request \(error.localizedDescription)")
         }
     }
-    
+
     func subscribe(pusherAuthResponse: PusherAuthResponse) {
         let event = Event(event: .subscribe, data: [
             "auth": pusherAuthResponse.auth,
             "channel": channelName
             ])
-        
+
         if let data = try? encoder.encode(event) {
             socket.write(data: data)
         }
@@ -180,11 +180,11 @@ private struct Event: Codable {
         case subscriptionSucceeded = "pusher_internal:subscription_succeeded"
         case clientTyping = "client-typing"
     }
-    
+
     let event: EventType
     let channel: String?
     let data: EventData
-    
+
     init(event: EventType, channel: String? = nil, data: [String: String]) {
         self.event = event
         self.channel = channel
@@ -196,9 +196,9 @@ struct EventData {
     /// Error that gets thrown when Event decoding error occurs
     struct EventDataDecodingError: Error {
     }
-    
+
     let data: [String: String]
-    
+
     init(data: [String: String]) {
         self.data = data
     }
@@ -210,14 +210,14 @@ extension EventData: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let dataRaw = try container.decode(String.self)
-        
+
         if let data = dataRaw.data(using: .utf8) {
             self.data = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String] ?? [:]
         } else {
             throw EventDataDecodingError()
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(data)

--- a/delighted/Classes/Pusher.swift
+++ b/delighted/Classes/Pusher.swift
@@ -40,7 +40,7 @@ class Pusher {
         self.baseAPIURL = baseAPIURL
         self.channelName = channelName
         self.surveyRequestToken = surveyRequestToken
-        socket = WebSocket(url: websocketURL)
+        socket = WebSocket(request: URLRequest(url: websocketURL))
         socket.delegate = self
     }
 }
@@ -152,29 +152,22 @@ private extension Pusher {
 }
 
 extension Pusher: WebSocketDelegate {
-    public func websocketDidConnect(socket: WebSocketClient) {
-        
-    }
-    
-    public func websocketDidReceiveData(socket: WebSocketClient, data: Data) {
-        
-    }
-    
-    public func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
-        
-    }
-    
-    public func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
-        guard let data = text.data(using: .utf8) else {
-            Logger.log(.error, "Invalid data from pusher")
-            return
-        }
-        
-        do {
-            let event = try decoder.decode(Event.self, from: data)
-            handleEvent(event: event)
-        } catch {
-            Logger.log(.error, "Error decoding pusher message: \(error.localizedDescription)")
+    func didReceive(event: WebSocketEvent, client: WebSocket) {
+        switch event {
+        case .text(let text):
+            guard let data = text.data(using: .utf8) else {
+                Logger.log(.error, "Invalid data from pusher")
+                return
+            }
+
+            do {
+                let event = try decoder.decode(Event.self, from: data)
+                handleEvent(event: event)
+            } catch {
+                Logger.log(.error, "Error decoding pusher message: \(error.localizedDescription)")
+            }
+        default:
+            break
         }
     }
 }

--- a/delighted/Classes/Pusher.swift
+++ b/delighted/Classes/Pusher.swift
@@ -78,7 +78,7 @@ extension Pusher {
         // Increments number of events sent
         // Encoding event to write to socket
         self.clientTypingLastSent = Date()
-        self.numberOfClientTypingsSent = self.numberOfClientTypingsSent + 1
+        self.numberOfClientTypingsSent += 1
 
         let event = Event(event: .clientTyping, channel: self.channelName, data: [
             "survey_request_token": self.surveyRequestToken
@@ -134,9 +134,9 @@ private extension Pusher {
             } catch {
                 Logger.log(.error, "Could not decode push auth response \(error.localizedDescription)")
             }
-        }) { (error) in
+        }, failure: { (error) in
             Logger.log(.error, "Error sending push auth request \(error.localizedDescription)")
-        }
+        })
     }
 
     func subscribe(pusherAuthResponse: PusherAuthResponse) {

--- a/delighted/Classes/Scale.swift
+++ b/delighted/Classes/Scale.swift
@@ -4,17 +4,17 @@ class Scale: UIView {
     let configuration: Configuration
     let minLabel: String
     let maxLabel: String
-    
+
     let minNumber: Int
     let maxNumber: Int
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(configuration: Configuration, minLabel: String, maxLabel: String, minNumber: Int, maxNumber: Int, onSelection: @escaping OnSelection) {
         self.configuration = configuration
         self.minLabel = minLabel
@@ -25,15 +25,15 @@ class Scale: UIView {
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var ces: CESComponent = {
         let view = CESComponent(
             configuration: configuration,
@@ -45,7 +45,7 @@ class Scale: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var nps: NPSComponent = {
         let view = NPSComponent(
             configuration: configuration,
@@ -57,23 +57,23 @@ class Scale: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var showNPS = {
         return maxNumber - minNumber > 5
     }()
-    
+
     func adjustForInitialDisplay() {
         if showNPS {
             nps.adjustForInitialDisplay()
         }
     }
-    
+
     private func setupView() {
         clipsToBounds = false
-        
+
         let view: UIView = showNPS ? nps : ces
         self.addSubview(view)
-        
+
         NSLayoutConstraint.activate([
             view.topAnchor.constraint(equalTo: self.topAnchor),
             view.bottomAnchor.constraint(equalTo: self.bottomAnchor),

--- a/delighted/Classes/Smileys.swift
+++ b/delighted/Classes/Smileys.swift
@@ -4,27 +4,27 @@ class SmileysComponent: UIView, Component {
     enum Value {
         case veryUnhappy, unhappy, neutral, happy, veryHappy
     }
-    
+
     let theme: Theme
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(theme: Theme, onSelection: @escaping OnSelection) {
         self.theme = theme
         self.onSelection = onSelection
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var buttons: [UIButton] = {
         return [
             makeButton(image: Images.smileyVeryUnhappy.image),
@@ -34,12 +34,12 @@ class SmileysComponent: UIView, Component {
             makeButton(image: Images.smileyVeryHappy.image)
         ]
     }()
-    
+
     private func setupView() {
         let component = ViewLayout.createCenterHorizontalStackView(subviews: buttons)
         component.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(component)
-        
+
         NSLayoutConstraint.activate([
             component.topAnchor.constraint(equalTo: self.topAnchor),
             component.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor),
@@ -48,47 +48,47 @@ class SmileysComponent: UIView, Component {
             component.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
-    
+
     private func makeButton(image: UIImage?) -> UIButton {
         let inactiveColor = theme.icon.inactiveBackgroundColor.color
         let activeColor = theme.icon.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
-        
+
         let button = TintStateButton()
         button.setImage(image, for: .normal)
         button.setImage(image, for: .highlighted)
         button.setImage(image, for: .selected)
         button.setImage(image, for: [.selected, .highlighted])
-        
+
         button.normalTintColor = inactiveColor
         button.highlightedTintColor = activeColor
         button.selectedTintColor = activeColor
         button.selectedHighlightedTintColor = darkerActiveColor
-        
+
         button.isSelected = true
-        
+
         button.addTarget(self, action: #selector(onSelection(sender:)), for: .touchUpInside)
-        
+
         button.width(constant: 55)
         button.height(constant: 55)
-        
+
         return button
     }
-    
+
     @objc func onSelection(sender: Any?) {
         Haptic.medium.generate()
-        
+
         guard let buttonSelected = sender as? UIButton else {
             Logger.log(.fatal, "Could not cast selected object as a button")
             return
         }
-        
+
         for button in buttons {
             button.isSelected = false
         }
-        
+
         buttonSelected.isSelected = true
-        
+
         if let index = buttons.firstIndex(of: buttonSelected) {
             // Adding 1 because smileys will always be value of 1 to 5
             let value = index + 1

--- a/delighted/Classes/Stars.swift
+++ b/delighted/Classes/Stars.swift
@@ -2,40 +2,40 @@ import UIKit
 
 class StarsComponent: UIView, Component {
     let theme: Theme
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(theme: Theme, onSelection: @escaping OnSelection) {
         self.theme = theme
         self.onSelection = onSelection
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var buttons: [UIButton] = {
         return [
             makeButton(),
             makeButton(),
             makeButton(),
             makeButton(),
-            makeButton(),
+            makeButton()
         ]
     }()
-    
+
     private func setupView() {
         let component = ViewLayout.createCenterHorizontalStackView(subviews: buttons)
         component.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(component)
-        
+
         NSLayoutConstraint.activate([
             component.topAnchor.constraint(equalTo: self.topAnchor),
             component.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor),
@@ -44,15 +44,15 @@ class StarsComponent: UIView, Component {
             component.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
-    
+
     private func makeButton() -> UIButton {
         let inactiveColor = theme.stars.inactiveBackgroundColor.color
         let activeColor = theme.stars.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
-        
+
         let button = TintStateButton()
         let selectedImage = Images.star.image
-        
+
         switch theme.buttonStyle {
         case .solid:
             let image = Images.star.image
@@ -60,7 +60,7 @@ class StarsComponent: UIView, Component {
             button.setImage(selectedImage, for: .highlighted)
             button.setImage(selectedImage, for: .selected)
             button.setImage(selectedImage, for: [.selected, .highlighted])
-            
+
             button.normalTintColor = inactiveColor
             button.highlightedTintColor = activeColor
             button.selectedTintColor = activeColor
@@ -71,13 +71,13 @@ class StarsComponent: UIView, Component {
             button.setImage(selectedImage, for: .highlighted)
             button.setImage(selectedImage, for: .selected)
             button.setImage(selectedImage, for: [.selected, .highlighted])
-            
+
             button.normalTintColor = inactiveColor
             button.highlightedTintColor = activeColor
             button.selectedTintColor = activeColor
             button.selectedHighlightedTintColor = darkerActiveColor
         }
-        
+
         button.addTarget(self, action: #selector(onSelection(sender:)), for: .touchUpInside)
         button.addTarget(self, action: #selector(highlightStars(sender:)), for: .touchDown)
         button.addTarget(self, action: #selector(unHighlightAll(sender:)), for: .touchUpOutside)
@@ -87,10 +87,10 @@ class StarsComponent: UIView, Component {
 
         button.width(constant: 55)
         button.height(constant: 55)
-        
+
         return button
     }
-    
+
     @objc func highlightStars(sender: Any?) {
         guard let buttonSelected = sender as? UIButton else {
             Logger.log(.fatal, "Could not cast selected object as a button")
@@ -105,30 +105,30 @@ class StarsComponent: UIView, Component {
             }
         }
     }
-    
+
     @objc func unHighlightAll(sender: Any?) {
         for button in buttons {
             button.isHighlighted = false
         }
     }
-    
+
     @objc func onSelection(sender: Any?) {
         Haptic.medium.generate()
-        
+
         guard let buttonSelected = sender as? UIButton else {
             Logger.log(.fatal, "Could not cast selected object as a button")
             return
         }
-        
+
         var selected = true
         for button in buttons {
             button.isSelected = selected
-            
+
             if button == buttonSelected {
                 selected = false
             }
         }
-        
+
         if let index = buttons.firstIndex(of: buttonSelected) {
             // Adding 1 because stars will always be value of 1 to 5
             let value = index + 1

--- a/delighted/Classes/Strings.swift
+++ b/delighted/Classes/Strings.swift
@@ -3,13 +3,13 @@ import UIKit
 extension String {
     func setParagraphStyle(lineSpacing: CGFloat, alignment: NSTextAlignment) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
-        
+
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = lineSpacing
         paragraphStyle.alignment = alignment
-        
-        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value:paragraphStyle, range:NSMakeRange(0, attributedString.length))
-        
+
+        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+
         return attributedString
     }
 }

--- a/delighted/Classes/Survey.swift
+++ b/delighted/Classes/Survey.swift
@@ -5,19 +5,19 @@ public struct Survey: Decodable {
     let type: SurveyType
     let configuration: Configuration
     let template: Template
-    
+
     public struct SurveyType: Decodable {
         let id: ID
         let groups: [Group]
-        
+
         enum CodingKeys: CodingKey {
             case id, groups, configuration
         }
-        
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             id = try container.decode(ID.self, forKey: .id)
-            
+
             let groupsDict = try container.decode([String: [String: Int]].self, forKey: .groups)
             groups = try groupsDict.map({ (key, value) in
                 guard let scoreMin = value["score_min"], let scoreMax = value["score_max"] else {
@@ -27,60 +27,60 @@ public struct Survey: Decodable {
                 return Group(name: key, scoreMin: scoreMin, scoreMax: scoreMax)
             })
         }
-        
+
         public enum ID: String, Decodable {
             case csat, ces, smileys, starsFive = "stars_five", thumbs, nps
         }
-        
+
         public struct Group {
             let name: String
             let scoreMin: Int
             let scoreMax: Int
         }
-        
+
         // TODO: Is this the right thing todo?
         struct GroupPropertyError: Error {
         }
     }
-    
+
     public struct Template: Decodable {
         let questionText: String
         let commentPrompts: [String: String]
         let additionalQuestions: [AdditionalQuestion]
-        
+
         enum CodingKeys: CodingKey {
             case questionText, commentPrompts, additionalQuestions
         }
-        
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             questionText = try container.decode(String.self, forKey: .questionText)
             commentPrompts = try container.decode([String: String].self, forKey: .commentPrompts)
-            
+
             if container.contains(.additionalQuestions) {
                 additionalQuestions = try container.decode([AdditionalQuestion].self, forKey: .additionalQuestions)
             } else {
                 additionalQuestions = []
             }
         }
-        
+
         public struct AdditionalQuestion: Decodable {
             let id: String
             let type: AdditionalQuestionType
             let text: String
-            
+
             let options: [Option]?
             let scaleMin: Int?
             let scaleMax: Int?
             let scaleMinLabel: String?
             let scaleMaxLabel: String?
-            
+
             let targetAudienceGroups: [String]?
 
             public enum AdditionalQuestionType: String, Decodable {
                 case selectOne = "select_one", selectMany = "select_many", scale, freeResponse = "free_response"
             }
-            
+
             public struct Option: Decodable {
                 let id: String
                 let text: String

--- a/delighted/Classes/SurveyRequest.swift
+++ b/delighted/Classes/SurveyRequest.swift
@@ -5,7 +5,7 @@ struct SurveyRequestBody: Encodable {
     let person: Person?
     let properties: Properties?
     let testMode: Bool
-    
+
     init(token: String? = nil, person: Person? = nil, properties: Properties? = nil, testMode: Bool? = nil) {
         self.token = token
         self.person = person

--- a/delighted/Classes/SurveyResponse.swift
+++ b/delighted/Classes/SurveyResponse.swift
@@ -2,34 +2,34 @@ import Foundation
 
 struct SurveyResponse: Encodable {
     let delightedID: String
-    
+
     let surveyRequestToken: String
     var score: Int?
     var comment: String?
-    
+
     private var additionalQuestions: [AdditionalQuestionAnswer]
-    
+
     enum CodingKeys: String, CodingKey {
         case surveyRequestToken, score, comment, additionalQuestions
     }
-    
+
     init(delightedID: String, surveyRequestToken: String, score: Int? = nil) {
         self.delightedID = delightedID
         self.surveyRequestToken = surveyRequestToken
         self.score = score
         self.additionalQuestions = []
     }
-    
+
     struct AdditionalQuestionAnswer: Codable {
         let id: String
         let value: String
     }
-    
+
     mutating func addAnswer(id: String, value: String) {
         additionalQuestions.removeAll { (answer) -> Bool in
             return answer.id == id
         }
-        
+
         let answer = AdditionalQuestionAnswer(id: id, value: value)
         additionalQuestions.append(answer)
     }

--- a/delighted/Classes/SurveySession.swift
+++ b/delighted/Classes/SurveySession.swift
@@ -110,9 +110,9 @@ extension SurveySession {
         sendRequest(route: route, completion: { [unowned self] (_, _) in
             self.status = .saveSuccessful
             Logger.log(.debug, "Survey response saved for Survey Request Token: \(self.surveyResponse.surveyRequestToken)")
-        }) { [unowned self] (error) in
+        }, failure: { [unowned self] (error) in
             self.status = .saveFailed
             Logger.log(.debug, "Survey response failed Survey Request Token: \(self.surveyResponse.surveyRequestToken) with \(error.localizedDescription)")
-        }
+        })
     }
 }

--- a/delighted/Classes/SurveyViewController.swift
+++ b/delighted/Classes/SurveyViewController.swift
@@ -3,20 +3,20 @@ import UIKit
 public class SurveyViewController: UIViewController, DelightedPageViewControllerPage {
     let pageViewController: DelightedPageViewController
     var session: SurveySession
-    
+
     var survey: Survey {
         return session.surveyRequest.survey
     }
     var configuration: Configuration {
         return session.configuration
     }
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
+
     var isFullScreen = false
-    
+
     let footerBottomMarging: CGFloat = 20
 
     init(pageViewController: DelightedPageViewController, session: SurveySession) {
@@ -24,15 +24,15 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         self.session = session
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
         session.disconnectPusher()
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -41,30 +41,30 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         tapGesture.delegate = self
         backgroundView.addGestureRecognizer(tapGesture)
         backgroundView.isUserInteractionEnabled = true
-        
+
         setupView()
     }
-    
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         show()
     }
-    
+
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         registerNotifications()
     }
-    
+
     public override func viewWillDisappear(_ animated: Bool) {
         view.endEditing(true)
         super.viewWillDisappear(animated)
     }
-    
+
     public override func viewDidDisappear(_ animated: Bool) {
         unregisterNotifications()
         super.viewDidDisappear(animated)
     }
-    
+
     public override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         pageViewController.dismiss(animated: flag, completion: completion)
     }
@@ -76,7 +76,7 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
             }
         }
     }
-    
+
     private lazy var backgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = Colors.semiTransparentBlack
@@ -84,32 +84,32 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var container: UIView = {
         let view = UIView()
         view.backgroundColor = theme.backgroundColor.color
-        
+
         view.clipsToBounds = true
         view.layer.cornerRadius = theme.containerCornerRadius
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var closeButton: UIButton = {
         let button = CloseButton(theme: theme)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(onCloseModal(sender:)), for: .touchUpInside)
-        
+
         return button
     }()
-    
+
     private lazy var closeButtonForNavController: UIButton = {
         let button = CloseButton(theme: theme)
         button.addTarget(self, action: #selector(onCloseNavigationController(sender:)), for: .touchUpInside)
-        
+
         return button
     }()
-    
+
     private lazy var questionLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -118,10 +118,10 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         label.font = configuration.font(ofSize: 18)
         label.textColor = theme.primaryTextColor.color
         label.numberOfLines = 0
-        
+
         return label
     }()
-    
+
     private lazy var questionComponent: Component = {
         let component: Component
         switch survey.type.id {
@@ -161,10 +161,10 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         }
 
         component.translatesAutoresizingMaskIntoConstraints = false
-        
+
         return component
     }()
-    
+
     private lazy var commentLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -172,17 +172,17 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         label.numberOfLines = 0
         label.textColor = theme.primaryTextColor.color
         label.font = configuration.font(ofSize: 16)
-        
+
         label.alpha = 0
         label.isHidden = true
-        
+
         return label
     }()
-    
+
     private lazy var commentTextView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         textView.layer.borderColor = theme.textarea.borderColor.color.cgColor
         textView.layer.borderWidth = 1
         textView.layer.cornerRadius = Configuration.cornerRadius
@@ -191,7 +191,7 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         textView.backgroundColor = theme.textarea.backgroundColor.color
         textView.textContainerInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         textView.delegate = self
-        
+
         switch configuration.theme.ios.keyboardAppearance {
         case .light?:
             textView.keyboardAppearance = .light
@@ -200,154 +200,154 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         case nil:
             ()
         }
-        
+
         textView.alpha = 0
         textView.isHidden = true
-        
+
         return textView
     }()
-    
+
     private lazy var submitButton: Button = {
         let button = Button(configuration: configuration, mode: .primary)
         button.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.setTitle(self.configuration.submitText, for: .normal)
         button.addTarget(self, action: #selector(onSubmit(sender:)), for: .touchUpInside)
-        
+
         button.alpha = 0
         button.isHidden = true
-        
+
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .center
-        
+
         return button
     }()
-    
+
     private lazy var poweredByLabel: PoweredBy = {
         let button = PoweredBy(configuration: self.configuration)
         button.isHidden = true
         button.alpha = 0
         return button
     }()
-    
+
     lazy var hiddenConstraintTop: NSLayoutConstraint = {
         let constraint =  container.topAnchor.constraint(equalTo: view.bottomAnchor)
         constraint.priority = UILayoutPriority.defaultLow
         return constraint
     }()
-    
+
     lazy var cardConstraintTop: NSLayoutConstraint = {
         let constraint = container.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         constraint.priority = UILayoutPriority.defaultHigh
         return constraint
     }()
-    
+
     lazy var modalConstraintCenter: NSLayoutConstraint = {
         let constraint = container.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         constraint.priority = UILayoutPriority.defaultHigh
         return constraint
     }()
-    
+
     lazy var fullScreenConstraintTop: NSLayoutConstraint = {
         let constraint = container.topAnchor.constraint(equalTo: view.topAnchor)
         constraint.priority = UILayoutPriority.defaultHigh
         return constraint
     }()
-    
+
     lazy var closeButtonConstraintTop: NSLayoutConstraint = {
         let constraint = closeButton.topAnchor.constraint(equalTo: container.topAnchor, constant: 0)
         return constraint
     }()
-    
+
     lazy var questionLabelConstraintTop: NSLayoutConstraint = {
         let constraint = questionLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 55)
         return constraint
     }()
-    
+
     lazy var fullHeightConstraint: NSLayoutConstraint = {
         let constraint = container.heightAnchor.constraint(equalTo: view.heightAnchor)
         constraint.priority = UILayoutPriority.defaultLow
         return constraint
     }()
-    
+
     lazy var containerEdgeLeadingConstraint: NSLayoutConstraint = {
         return container.leadingAnchor.constraint(equalTo: view.leadingAnchor)
     }()
-    
+
     lazy var containerEdgeTrailingConstraint: NSLayoutConstraint = {
         return container.trailingAnchor.constraint(equalTo: view.trailingAnchor)
     }()
-    
+
     var containerEdgeMargin: CGFloat = 0 {
         didSet {
             containerEdgeLeadingConstraint.constant = containerEdgeMargin
             containerEdgeTrailingConstraint.constant = -containerEdgeMargin
         }
     }
-    
+
     private lazy var footerBottomConstraint: NSLayoutConstraint = {
         return poweredByLabel.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -40)
     }()
-    
+
     func onSelection(value: Int) {
         session.sendClientTyping()
-        
+
         // Save survey response on API
         session.surveyResponse.score = value
         session.saveSurveyResponse()
-        
+
         // Update comment prompt based on answer
         let commentPrompt = survey.template.commentPrompts["\(value)"]
         commentLabel.attributedText = commentPrompt?.setParagraphStyle(lineSpacing: 3, alignment: .center)
-        
+
         // Update card/modal to full screen
         fullScreenIfNeeded()
     }
-    
+
     private func sendToCallback() {
         session.callback?(.surveyClosed(session.status))
     }
-    
+
     @objc func onCloseModal(sender: Any?) {
         view.endEditing(true)
         session.disconnectPusher()
-        
+
         if isFullScreen {
             dismiss(animated: true) { [weak self] in
                 self?.sendToCallback()
             }
         } else {
-            hide() { [weak self] in
+            hide { [weak self] in
                 self?.dismiss(animated: false) { [weak self] in
                     self?.sendToCallback()
                 }
             }
         }
-        
+
     }
-    
+
     @objc func onCloseNavigationController(sender: Any?) {
         session.disconnectPusher()
-        
+
         pageViewController.dismiss(animated: true) { [weak self] in
             self?.sendToCallback()
         }
     }
-    
+
     @objc func onSubmit(sender: Any?) {
         session.sendClientTyping()
-        
+
         // Update comment text and save to API
         session.surveyResponse.comment = commentTextView.text
         session.saveSurveyResponse()
-        
+
         // Hide close button on view controll and add on to navigation controller
         // This keeps close button static between view controller pushes
         closeButton.isHidden = true
         let frame = self.closeButton.frame
         closeButtonForNavController.frame = frame
         pageViewController.view.addSubview(closeButtonForNavController)
-        
+
         let questions = session.surveyRequest.survey.template.additionalQuestions
 
         if questions.count == 0 {
@@ -356,7 +356,7 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
             pageViewController.state = .additionalQuestions
         }
     }
-    
+
     public func show() {
         switch configuration.theme.display {
         case .card:
@@ -365,28 +365,28 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
             showModal()
         }
     }
-    
+
     // Animate in the card looking modal
-    public func hide(completion: (() -> ())? = nil) {
+    public func hide(completion: (() -> Void)? = nil) {
         UIView.animate(withDuration: 0.2) { [weak self] in
             self?.backgroundView.alpha = 0
             self?.closeButtonForNavController.isHidden = true
         }
-        
+
         // Spring animate in the modal
         hiddenConstraintTop.isActive = true
         cardConstraintTop.isActive = false
         fullScreenConstraintTop.isActive = false
         modalConstraintCenter.isActive = false
-        
-        UIView.animate(withDuration:0.7,
+
+        UIView.animate(withDuration: 0.7,
                        delay: 0.0,
                        usingSpringWithDamping: 0.65,
                        initialSpringVelocity: 0.15,
                        options: [],
                        animations: { [weak self] in
                         self?.view.layoutIfNeeded()
-            }, completion: { (value: Bool) in
+            }, completion: { (_: Bool) in
                 completion?()
         })
     }
@@ -402,7 +402,7 @@ private extension SurveyViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         #endif
     }
-    
+
     func unregisterNotifications() {
         #if swift(>=4.2)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -412,21 +412,21 @@ private extension SurveyViewController {
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         #endif
     }
-    
-    @objc func keyboardWillShow(notification: NSNotification){
+
+    @objc func keyboardWillShow(notification: NSNotification) {
         #if swift(>=4.2)
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         #else
         guard let keyboardFrame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue else { return }
         #endif
-        
+
         let height = self.view.convert(keyboardFrame.cgRectValue, from: nil).size.height
         KeyboardHeightHistory.lastHeight = height
         footerBottomConstraint.constant = -(height + footerBottomMarging)
     }
-    
-    @objc func keyboardWillHide(notification: NSNotification){
-        
+
+    @objc func keyboardWillHide(notification: NSNotification) {
+
     }
 }
 
@@ -453,7 +453,7 @@ private extension SurveyViewController {
         container.addSubview(commentTextView)
         container.addSubview(submitButton)
         container.addSubview(poweredByLabel)
-        
+
         // 40px for components with labels below
         // 60px for everything else
         let componentBottomMargin: CGFloat = {
@@ -464,53 +464,53 @@ private extension SurveyViewController {
                 return 60
             }
         }()
-        
+
         let verticalSpacing: CGFloat = 20
         let sidePadding: CGFloat = 25
-        
+
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
             backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            
+
             containerEdgeLeadingConstraint,
             containerEdgeTrailingConstraint,
             hiddenConstraintTop,
-            
+
             closeButtonConstraintTop,
             closeButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: 0),
             closeButton.widthAnchor.constraint(equalToConstant: 50),
             closeButton.heightAnchor.constraint(equalToConstant: 50),
-            
+
             questionLabelConstraintTop,
             questionLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: sidePadding),
             questionLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -sidePadding),
-            
+
             questionComponent.topAnchor.constraint(equalTo: questionLabel.bottomAnchor, constant: verticalSpacing),
             questionComponent.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             questionComponent.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: sidePadding),
             questionComponent.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -sidePadding),
-            
+
             commentLabel.topAnchor.constraint(equalTo: questionComponent.bottomAnchor, constant: verticalSpacing),
             commentLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: sidePadding),
             commentLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -sidePadding),
-            
+
             commentTextView.topAnchor.constraint(equalTo: commentLabel.bottomAnchor, constant: verticalSpacing),
             commentTextView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: sidePadding),
             commentTextView.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -sidePadding),
-            
+
             submitButton.topAnchor.constraint(equalTo: commentTextView.bottomAnchor, constant: verticalSpacing),
             submitButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: sidePadding),
             submitButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -sidePadding),
             submitButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 50),
-            
+
             poweredByLabel.topAnchor.constraint(equalTo: submitButton.bottomAnchor, constant: verticalSpacing),
             poweredByLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            
+
             container.bottomAnchor.constraint(greaterThanOrEqualTo: questionComponent.bottomAnchor, constant: componentBottomMargin)
         ])
-        
+
         containerEdgeMargin = 0
         view.layoutIfNeeded()
     }
@@ -518,102 +518,102 @@ private extension SurveyViewController {
 
 private extension SurveyViewController {
     // Animate in the card looking modal
-    func showCard(completion: (() -> ())? = nil) {
+    func showCard(completion: (() -> Void)? = nil) {
         UIView.animate(withDuration: 0.2) { [weak self] in
             self?.backgroundView.alpha = 1
         }
-        
+
         // Spring animate in the modal
         hiddenConstraintTop.isActive = false
         cardConstraintTop.isActive = true
         fullScreenConstraintTop.isActive = false
 
-        UIView.animate(withDuration:0.6,
+        UIView.animate(withDuration: 0.6,
                        delay: 0.0,
                        usingSpringWithDamping: 0.9,
                        initialSpringVelocity: 0.75,
                        options: [],
                        animations: { [weak self] in
                         self?.view.layoutIfNeeded()
-            }, completion: { [weak self] (value: Bool) in
+            }, completion: { [weak self] (_: Bool) in
                 self?.questionComponent.adjustForInitialDisplay()
         })
     }
-    
+
     // Animate in the card looking modal
-    func showModal(completion: (() -> ())? = nil) {
+    func showModal(completion: (() -> Void)? = nil) {
         containerEdgeMargin = configuration.modalMargin
         view.layoutIfNeeded()
-        
+
         UIView.animate(withDuration: 0.2) { [weak self] in
             self?.backgroundView.alpha = 1
         }
-        
+
         // Spring animate in the modal
         hiddenConstraintTop.isActive = false
         modalConstraintCenter.isActive = true
         fullScreenConstraintTop.isActive = false
-        
-        UIView.animate(withDuration:0.6,
+
+        UIView.animate(withDuration: 0.6,
                        delay: 0.0,
                        usingSpringWithDamping: 0.9,
                        initialSpringVelocity: 0.75,
                        options: [],
                        animations: { [weak self] in
                         self?.view.layoutIfNeeded()
-            }, completion: { [weak self] (value: Bool) in
+            }, completion: { [weak self] (_: Bool) in
                 self?.questionComponent.adjustForInitialDisplay()
         })
     }
-    
+
     // Expand view from modal to full screen
     func fullScreenIfNeeded() {
         guard !isFullScreen else { return }
-        
+
         commentTextView.becomeFirstResponder()
         commentTextView.resignFirstResponder()
-        
+
         // This constants gets set in the keyboard notifications
         // We turn it on here when going full screen so the view gets properly
         // placed above the keyboard
         footerBottomConstraint.isActive = true
-        
+
         commentLabel.isHidden = false
         commentTextView.isHidden = false
         submitButton.isHidden = false
         poweredByLabel.isHidden = false
-        
+
         // Hide the original question
         questionLabel.height(constant: 0)
-        
+
         closeButtonConstraintTop.constant = 35
         questionLabelConstraintTop.constant = 70
         hiddenConstraintTop.isActive = false
         cardConstraintTop.isActive = false
-        
+
         fullScreenConstraintTop.isActive = true
         fullHeightConstraint.isActive = true
-        
+
         questionComponent.adjustForFullScreen()
         containerEdgeMargin = 0
-        
+
         // Expand animate to full screen
         // Show the text area and text area label
         UIView.animate(withDuration: 0.35, delay: 0, options: .curveEaseOut, animations: { [weak self] in
             self?.view.layoutIfNeeded()
-            
+
             self?.view.layer.cornerRadius = 0
-            
+
             self?.commentLabel.alpha = 1
             self?.commentTextView.alpha = 1
             self?.submitButton.alpha = 1
             self?.poweredByLabel.alpha = 1
-        }) { [weak self] (value: Bool) in
+        }) { [weak self] (_: Bool) in
             self?.isFullScreen = true
             self?.commentTextView.becomeFirstResponder()
-            
+
             Delighted.window?.backgroundColor = self?.configuration.theme.backgroundColor.color
-            
+
             // This is a work around for the cursor not appear and/or not
             // appearing with the right textContainerInset set
             // Adding a new line and removing it resets the textContainerInset from not

--- a/delighted/Classes/SurveyViewController.swift
+++ b/delighted/Classes/SurveyViewController.swift
@@ -608,7 +608,7 @@ private extension SurveyViewController {
             self?.commentTextView.alpha = 1
             self?.submitButton.alpha = 1
             self?.poweredByLabel.alpha = 1
-        }) { [weak self] (_: Bool) in
+        }, completion: { [weak self] (_: Bool) in
             self?.isFullScreen = true
             self?.commentTextView.becomeFirstResponder()
 
@@ -620,6 +620,6 @@ private extension SurveyViewController {
             // showing which may be from some animation issues
             self?.commentTextView.text = "\n"
             self?.commentTextView.text = ""
-        }
+        })
     }
 }

--- a/delighted/Classes/TextArea.swift
+++ b/delighted/Classes/TextArea.swift
@@ -1,30 +1,30 @@
 import UIKit
 
 class TextArea: UIView, Component {
-    typealias OnSelection = (String) -> ()
+    typealias OnSelection = (String) -> Void
     let onSelection: OnSelection
-    
+
     let configuration: Configuration
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
+
     init(configuration: Configuration, onSelection: @escaping OnSelection) {
         self.configuration = configuration
         self.onSelection = onSelection
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -36,7 +36,7 @@ class TextArea: UIView, Component {
         textView.backgroundColor = theme.textarea.backgroundColor.color
         textView.textContainerInset = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         textView.delegate = self
-        
+
         switch configuration.theme.ios.keyboardAppearance {
         case .light?:
             textView.keyboardAppearance = .light
@@ -45,18 +45,18 @@ class TextArea: UIView, Component {
         case nil:
             ()
         }
-        
+
         return textView
     }()
-    
+
     @discardableResult
     override func becomeFirstResponder() -> Bool {
         return textView.becomeFirstResponder()
     }
-    
+
     private func setupView() {
         self.addSubview(textView)
-        
+
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: self.topAnchor),
             textView.leadingAnchor.constraint(equalTo: self.leadingAnchor),

--- a/delighted/Classes/ThankYou.swift
+++ b/delighted/Classes/ThankYou.swift
@@ -4,16 +4,16 @@ public struct ThankYou: Decodable {
     let text: String
     let autoCloseDelay: Int?
     let groups: [Group]
-    
+
     enum CodingKeys: CodingKey {
         case text, autoCloseDelay, groups
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         text = try container.decode(String.self, forKey: .text)
         autoCloseDelay = try container.decode(Int?.self, forKey: .autoCloseDelay)
-        
+
         if container.contains(.groups) {
             let groupsDict = try container.decode([String: [String: String]].self, forKey: .groups)
             groups = try groupsDict.map({ (key, value) in
@@ -31,14 +31,14 @@ public struct ThankYou: Decodable {
             groups = []
         }
     }
-    
+
     public struct Group {
         let name: String
         let messageText: String?
         let linkText: String?
         let linkURL: String?
     }
-    
+
     enum GroupPropertyError: Error {
         case missingLinkText
         case missingLinkURL

--- a/delighted/Classes/ThankYouViewController.swift
+++ b/delighted/Classes/ThankYouViewController.swift
@@ -122,7 +122,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
     
     @objc func onLinkClick(sender: Any?) {
         if let thankYouGroup = thankYouGroup, let url = URL(string: thankYouGroup.linkURL!), UIApplication.shared.canOpenURL(url)  {
-            UIApplication.shared.openURL(url)
+            UIApplication.shared.open(url, options: [:])
         }
     }
 }

--- a/delighted/Classes/ThankYouViewController.swift
+++ b/delighted/Classes/ThankYouViewController.swift
@@ -3,52 +3,52 @@ import UIKit
 public class ThankYouViewController: UIViewController, DelightedPageViewControllerPage {
     let pageViewController: DelightedPageViewController
     let session: SurveySession
-    
+
     var configuration: Configuration {
         return session.configuration
     }
-    
+
     var theme: Theme {
         return configuration.theme
     }
-    
+
     lazy var task = DispatchWorkItem { [weak self] in
-        self?.pageViewController.dismiss(animated: true){ [weak self] in
+        self?.pageViewController.dismiss(animated: true) { [weak self] in
             self?.sendToCallback()
         }
     }
-    
+
     init(pageViewController: DelightedPageViewController, session: SurveySession) {
         self.pageViewController = pageViewController
         self.session = session
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupView()
     }
-    
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         // Auto dismiss if thank you constains autoCloseDelay
         // First takes it from developer override and then from the thank you configuration
         if let delay = configuration.thankYouAutoCloseDelay ?? session.surveyRequest.thankYou.autoCloseDelay {
             DispatchQueue.main.asyncAfter(deadline: .now() + TimeInterval(delay), execute: task)
         }
     }
-    
+
     public override func viewWillDisappear(_ animated: Bool) {
         task.cancel()
         super.viewWillDisappear(animated)
     }
-    
+
     private func sendToCallback() {
         session.callback?(.surveyClosed(session.status))
     }
@@ -58,7 +58,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var textLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -68,7 +68,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
         label.textColor = theme.primaryTextColor.color
         return label
     }()
-    
+
     private lazy var messageLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -78,7 +78,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
         label.textColor = theme.secondaryTextColor.color
         return label
     }()
-    
+
     private lazy var linkButton: Button = {
         let button = Button(configuration: configuration, mode: .primary)
         button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
@@ -86,42 +86,42 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
         button.addTarget(self, action: #selector(onLinkClick(sender:)), for: .touchUpInside)
         return button
     }()
-    
+
     private lazy var footerContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-    
+
     private lazy var poweredByLabel: PoweredBy = {
         let button = PoweredBy(configuration: self.configuration)
         return button
     }()
-    
+
     private lazy var thankYouGroup: ThankYou.Group? = {
         guard let score = session.surveyResponse.score else {
             return nil
         }
-        
+
         let surveyGroup = session.surveyRequest.survey.type.groups.first(where: { (group) -> Bool in
             return group.scoreMin...group.scoreMax ~= score
         })
-        
+
         if let name = surveyGroup?.name {
             return session.surveyRequest.thankYou.groups.first(where: { (group) -> Bool in
                 return group.name == name
             })
         }
-        
+
         return nil
     }()
-    
+
     @objc func onClose(sender: Any?) {
         dismiss(animated: true)
     }
-    
+
     @objc func onLinkClick(sender: Any?) {
-        if let thankYouGroup = thankYouGroup, let url = URL(string: thankYouGroup.linkURL!), UIApplication.shared.canOpenURL(url)  {
+        if let thankYouGroup = thankYouGroup, let url = URL(string: thankYouGroup.linkURL!), UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url, options: [:])
         }
     }
@@ -130,7 +130,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
 private extension ThankYouViewController {
     private func setupView() {
         view.backgroundColor = theme.backgroundColor.color
-        
+
         view.addSubview(containerView)
         containerView.addSubview(textLabel)
         containerView.addSubview(messageLabel)
@@ -138,16 +138,16 @@ private extension ThankYouViewController {
 
         view.addSubview(footerContainer)
         footerContainer.addSubview(poweredByLabel)
-        
+
         textLabel.text = session.surveyRequest.thankYou.text
         messageLabel.text = thankYouGroup?.messageText
-        
+
         if let thankYouLinkText = thankYouGroup?.linkText {
             linkButton.setTitle(thankYouLinkText, for: .normal)
         } else {
             linkButton.isHidden = true
         }
-        
+
         NSLayoutConstraint.activate([
             textLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             textLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
@@ -161,11 +161,11 @@ private extension ThankYouViewController {
             linkButton.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: 20),
             linkButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             linkButton.heightAnchor.constraint(equalToConstant: 50),
-            
+
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            
+
             footerContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             footerContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
             footerContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -30),
@@ -173,7 +173,7 @@ private extension ThankYouViewController {
             poweredByLabel.leadingAnchor.constraint(equalTo: footerContainer.leadingAnchor),
             poweredByLabel.trailingAnchor.constraint(equalTo: footerContainer.trailingAnchor),
             poweredByLabel.topAnchor.constraint(equalTo: footerContainer.topAnchor, constant: 10),
-            poweredByLabel.bottomAnchor.constraint(equalTo: footerContainer.bottomAnchor),
+            poweredByLabel.bottomAnchor.constraint(equalTo: footerContainer.bottomAnchor)
         ])
     }
 }

--- a/delighted/Classes/Theme.swift
+++ b/delighted/Classes/Theme.swift
@@ -19,7 +19,7 @@ public struct Theme: Decodable {
     let slider: Slider
     let closeButton: CloseButton
     let ios: IOS
-    
+
     public init(display: Display, containerCornerRadius: CGFloat, primaryColor: UIColor, buttonStyle: ThemeStyle,
                 buttonShape: ThemeShape, backgroundColor: UIColor, primaryTextColor: UIColor,
                 secondaryTextColor: UIColor, textarea: TextArea, primaryButton: PrimaryButton,
@@ -44,43 +44,43 @@ public struct Theme: Decodable {
         self.closeButton = closeButton
         self.ios = ios
     }
-    
+
     public struct TextArea: Decodable {
         let backgroundColor: Color
         let textColor: Color
         let borderColor: Color
-        
+
         public init(backgroundColor: UIColor, textColor: UIColor, borderColor: UIColor) {
             self.backgroundColor = Color(color: backgroundColor)
             self.textColor = Color(color: textColor)
             self.borderColor = Color(color: borderColor)
         }
     }
-    
+
     public struct PrimaryButton: Decodable {
         let backgroundColor: Color
         let textColor: Color
         let borderColor: Color
-        
+
         public init(backgroundColor: UIColor, textColor: UIColor, borderColor: UIColor) {
             self.backgroundColor = Color(color: backgroundColor)
             self.textColor = Color(color: textColor)
             self.borderColor = Color(color: borderColor)
         }
     }
-    
+
     public struct SecondaryButton: Decodable {
         let backgroundColor: Color
         let textColor: Color
         let borderColor: Color
-        
+
         public init(backgroundColor: UIColor, textColor: UIColor, borderColor: UIColor) {
             self.backgroundColor = Color(color: backgroundColor)
             self.textColor = Color(color: textColor)
             self.borderColor = Color(color: borderColor)
         }
     }
-    
+
     public struct Button: Decodable {
         let activeBackgroundColor: Color
         let activeTextColor: Color
@@ -88,7 +88,7 @@ public struct Theme: Decodable {
         let inactiveBackgroundColor: Color
         let inactiveTextColor: Color
         let inactiveBorderColor: Color
-        
+
         public init(activeBackgroundColor: UIColor, activeTextColor: UIColor, activeBorderColor: UIColor,
                     inactiveBackgroundColor: UIColor, inactiveTextColor: UIColor, inactiveBorderColor: UIColor) {
             self.activeBackgroundColor = Color(color: activeBackgroundColor)
@@ -99,27 +99,27 @@ public struct Theme: Decodable {
             self.inactiveBorderColor = Color(color: inactiveBorderColor)
         }
     }
-    
+
     public struct Stars: Decodable {
         let activeBackgroundColor: Color
         let inactiveBackgroundColor: Color
-        
+
         public init(activeBackgroundColor: UIColor, inactiveBackgroundColor: UIColor) {
             self.activeBackgroundColor = Color(color: activeBackgroundColor)
             self.inactiveBackgroundColor = Color(color: inactiveBackgroundColor)
         }
     }
-    
+
     public struct Icon: Decodable {
         let activeBackgroundColor: Color
         let inactiveBackgroundColor: Color
-        
+
         public init(activeBackgroundColor: UIColor, inactiveBackgroundColor: UIColor) {
             self.activeBackgroundColor = Color(color: activeBackgroundColor)
             self.inactiveBackgroundColor = Color(color: inactiveBackgroundColor)
         }
     }
-    
+
     public struct Scale: Decodable {
         let activeBackgroundColor: Color
         let activeTextColor: Color
@@ -127,7 +127,7 @@ public struct Theme: Decodable {
         let inactiveBackgroundColor: Color
         let inactiveTextColor: Color
         let inactiveBorderColor: Color
-        
+
         public init(activeBackgroundColor: UIColor, activeTextColor: UIColor, activeBorderColor: UIColor,
                     inactiveBackgroundColor: UIColor, inactiveTextColor: UIColor, inactiveBorderColor: UIColor) {
             self.activeBackgroundColor = Color(color: activeBackgroundColor)
@@ -138,7 +138,7 @@ public struct Theme: Decodable {
             self.inactiveBorderColor = Color(color: inactiveBorderColor)
         }
     }
-    
+
     public struct Slider: Decodable {
         let knobBackgroundColor: Color
         let knobTextColor: Color
@@ -148,7 +148,7 @@ public struct Theme: Decodable {
         let hoverBackgroundColor: Color
         let hoverTextColor: Color
         let hoverBorderColor: Color
-        
+
         public init(knobBackgroundColor: UIColor, knobTextColor: UIColor, knobBorderColor: UIColor,
                     trackActiveColor: UIColor, trackInactiveColor: UIColor, hoverBackgroundColor: UIColor, hoverTextColor: UIColor, hoverBorderColor: UIColor) {
             self.knobBackgroundColor = Color(color: knobBackgroundColor)
@@ -161,7 +161,7 @@ public struct Theme: Decodable {
             self.hoverBorderColor = Color(color: hoverBorderColor)
         }
     }
-    
+
     public struct CloseButton: Decodable {
         let normalBackgroundColor: Color
         let normalTextColor: Color
@@ -169,7 +169,7 @@ public struct Theme: Decodable {
         let highlightedBackgroundColor: Color
         let highlightedTextColor: Color
         let highlightedBorderColor: Color
-        
+
         public init(normalBackgroundColor: UIColor, normalTextColor: UIColor, normalBorderColor: UIColor,
                     highlightedBackgroundColor: UIColor, highlightedTextColor: UIColor, highlightedBorderColor: UIColor) {
             self.normalBackgroundColor = Color(color: normalBackgroundColor)
@@ -180,7 +180,7 @@ public struct Theme: Decodable {
             self.highlightedBorderColor = Color(color: highlightedBorderColor)
         }
     }
-    
+
     public struct IOS: Decodable {
         public enum KeyboardAppearance: String, Decodable {
             case light, dark
@@ -188,25 +188,25 @@ public struct Theme: Decodable {
         public enum StatusBarMode: String, Decodable {
             case lightContent = "light_content", darkContent = "dark_content"
         }
-        
+
         let keyboardAppearance: KeyboardAppearance?
         let statusBarMode: StatusBarMode?
         let statusBarHidden: Bool?
-        
+
         public init(keyboardAppearance: KeyboardAppearance? = nil, statusBarMode: StatusBarMode?, statusBarHidden: Bool?) {
             self.keyboardAppearance = keyboardAppearance
             self.statusBarMode = statusBarMode
             self.statusBarHidden = statusBarHidden
         }
-        
+
         enum CodingKeys: CodingKey {
             case keyboardAppearance, statusBarMode, statusBarHidden
         }
     }
-    
+
     public struct Color {
         let color: UIColor
-        
+
         init(color: UIColor) {
             self.color = color
         }
@@ -217,7 +217,7 @@ extension Theme.Color: Decodable {
     enum CodingKeys: CodingKey {
         case color
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let hexString = try container.decode(String.self)

--- a/delighted/Classes/Thumbs.swift
+++ b/delighted/Classes/Thumbs.swift
@@ -2,42 +2,42 @@ import UIKit
 
 class ThumbsComponent: UIView, Component {
     let theme: Theme
-    
-    typealias OnSelection = (Int) -> ()
+
+    typealias OnSelection = (Int) -> Void
     let onSelection: OnSelection
-    
+
     init(theme: Theme, onSelection: @escaping OnSelection) {
         self.theme = theme
         self.onSelection = onSelection
         super.init(frame: CGRect.zero)
         setupView()
     }
-    
+
     override init(frame: CGRect) {
         fatalError()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+
     private lazy var thumbsUpButton: UIButton = {
         return makeButton(image: Images.thumbsUp.image)
     }()
-    
+
     private lazy var thumbsDownButton: UIButton = {
         return makeButton(image: Images.thumbsDown.image)
     }()
-    
+
     private lazy var buttons: [UIButton] = {
         return [thumbsUpButton, thumbsDownButton]
     }()
-    
+
     private func setupView() {
         let component = ViewLayout.createCenterHorizontalStackView(subviews: buttons, spacing: 15)
         component.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(component)
-        
+
         NSLayoutConstraint.activate([
             component.topAnchor.constraint(equalTo: self.topAnchor),
             component.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor),
@@ -46,43 +46,43 @@ class ThumbsComponent: UIView, Component {
             component.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
-    
+
     private func makeButton(image: UIImage?) -> UIButton {
         let inactiveColor = theme.icon.inactiveBackgroundColor.color
         let activeColor = theme.icon.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
-        
+
         let button = TintStateButton()
         button.setImage(image, for: .normal)
         button.setImage(image, for: .highlighted)
         button.setImage(image, for: .selected)
         button.setImage(image, for: [.selected, .highlighted])
-        
+
         button.normalTintColor = inactiveColor
         button.highlightedTintColor = activeColor
         button.selectedTintColor = activeColor
         button.selectedHighlightedTintColor = darkerActiveColor
-        
+
         button.isSelected = true
-        
+
         button.addTarget(self, action: #selector(onSelection(sender:)), for: .touchUpInside)
-        
+
         button.width(constant: 55)
         button.height(constant: 55)
-        
+
         return button
     }
-    
+
     @objc func onSelection(sender: Any?) {
         Haptic.medium.generate()
-        
+
         for button in buttons {
             button.isSelected = false
         }
-        
+
         let button = sender as? UIButton
         button?.isSelected = true
-        
+
         switch button {
         case thumbsUpButton:
             onSelection(1)

--- a/delighted/Classes/ViewLayout.swift
+++ b/delighted/Classes/ViewLayout.swift
@@ -12,10 +12,10 @@ struct ViewLayout {
         stackView.alignment = .fill
         stackView.spacing = spacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         return stackView
     }
-    
+
     static func createCenterHorizontalStackView(subviews: [UIView], alignment: UIStackView.Alignment = .center, distribution: UIStackView.Distribution = .fillEqually, spacing: CGFloat = 5) -> UIStackView {
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.axis = .horizontal
@@ -23,7 +23,7 @@ struct ViewLayout {
         stackView.alignment = alignment
         stackView.spacing = spacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         return stackView
     }
 }
@@ -34,7 +34,7 @@ extension UIView {
             self.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -(edges?.right ?? 0)),
             self.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: edges?.left ?? 0),
             self.topAnchor.constraint(equalTo: view.topAnchor, constant: edges?.top ?? 0),
-            self.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -(edges?.bottom ?? 0)),
+            self.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -(edges?.bottom ?? 0))
         ])
     }
 }
@@ -50,7 +50,7 @@ extension UIView {
                            constant: constant)
         setConstraint(constraint: constraint)
     }
-    
+
     func width(constant: CGFloat) {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .width,
@@ -62,7 +62,7 @@ extension UIView {
         constraint.priority = .defaultHigh
         setConstraint(constraint: constraint)
     }
-    
+
     func heightEqualWidth() {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .height,
@@ -74,7 +74,7 @@ extension UIView {
         constraint.priority = .defaultHigh
         setConstraint(constraint: constraint)
     }
-    
+
     private func removeConstraint(attribute: NSLayoutConstraint.Attribute) {
         constraints.forEach {
             if $0.firstAttribute == attribute {
@@ -82,7 +82,7 @@ extension UIView {
             }
         }
     }
-    
+
     private func setConstraint(constraint: NSLayoutConstraint) {
         removeConstraint(attribute: constraint.firstAttribute)
         self.addConstraint(constraint)


### PR DESCRIPTION
The dependency for Starscream was significantly out of date, so I updated it to 4.0.4. The key difference in 4.0.4 and 3.1.1 is the change from `websocketDidReceiveMessage(socket: WebSocketClient, text: String)` to `didReceive(event: WebSocketEvent, client: WebSocket)`, which is documented in https://github.com/daltoniam/Starscream/issues/833. With iOS 15 and updates to Swift coming it's good to have this as up to date as possible.

I also added a `.swiftlint.yml` and made some minor style changes (such as removing whitespace, unused variables, unneeded semicolons, etc).

