### PR TITLE
Show "Next" instead of "Submit" when a survey has additional questions

### DIFF
--- a/delighted/Classes/SurveyViewController.swift
+++ b/delighted/Classes/SurveyViewController.swift
@@ -211,7 +211,8 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
         let button = Button(configuration: configuration, mode: .primary)
         button.translatesAutoresizingMaskIntoConstraints = false
 
-        button.setTitle(self.configuration.submitText, for: .normal)
+        let buttonTitle = self.survey.template.additionalQuestions.isEmpty ? self.configuration.submitText : self.configuration.nextText
+        button.setTitle(buttonTitle, for: .normal)
         button.addTarget(self, action: #selector(onSubmit(sender:)), for: .touchUpInside)
 
         button.alpha = 0


### PR DESCRIPTION
When a person is prompted for a comment, the button text should be "Next"
when a survey has additional questions and "Submit" when there are no
questions.