### PR TITLE
Rename `configuration` to `surveyConfiguration`

### DIFF
--- a/delighted/Classes/AdditionalQuestionViewController.swift
+++ b/delighted/Classes/AdditionalQuestionViewController.swift
@@ -152,7 +152,7 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
     }()
 
     private lazy var nextButton: UIButton = {
-        let button = Button(configuration: configuration, mode: .primary)
+        let button = Button(surveyConfiguration: configuration, mode: .primary)
         button.translatesAutoresizingMaskIntoConstraints = false
 
         button.setTitle(configuration.nextText, for: .normal)
@@ -169,7 +169,7 @@ public class AdditionalQuestionViewController: UIViewController, DelightedPageVi
     }()
 
     private lazy var previousButton: UIButton = {
-        let button = Button(configuration: configuration, mode: .secondary)
+        let button = Button(surveyConfiguration: configuration, mode: .secondary)
         button.translatesAutoresizingMaskIntoConstraints = false
 
         button.setTitle(configuration.prevText, for: .normal)

--- a/delighted/Classes/Button.swift
+++ b/delighted/Classes/Button.swift
@@ -2,10 +2,10 @@ import UIKit
 
 class TintStateButton: UIButton {
     let labelPaddingTop: CGFloat = 8.0
-    let configuration: SurveyConfiguration
+    let surveyConfiguration: SurveyConfiguration
 
     var theme: Theme {
-        return configuration.theme
+        return surveyConfiguration.theme
     }
 
     var normalTintColor: UIColor? = nil {
@@ -29,8 +29,8 @@ class TintStateButton: UIButton {
            }
        }
 
-    init(configuration: SurveyConfiguration) {
-        self.configuration = configuration
+    init(surveyConfiguration: SurveyConfiguration) {
+        self.surveyConfiguration = surveyConfiguration
         super.init(frame: .zero)
 
         apply()
@@ -92,7 +92,7 @@ class TintStateButton: UIButton {
     private func apply() {
         layer.masksToBounds = true
         titleLabel?.textAlignment = .center
-        titleLabel?.font = configuration.font(ofSize: 14)
+        titleLabel?.font = surveyConfiguration.font(ofSize: 14)
 
         setTitleColor(theme.primaryTextColor.color, for: .normal)
         setTitleColor(theme.primaryTextColor.color, for: [.normal, .highlighted])
@@ -120,8 +120,8 @@ class Button: UIButton {
         case primary, secondary, scale, button
     }
 
-    init(configuration: SurveyConfiguration, mode: Mode) {
-        self.surveyConfiguration = configuration
+    init(surveyConfiguration: SurveyConfiguration, mode: Mode) {
+        self.surveyConfiguration = surveyConfiguration
         self.mode = mode
         super.init(frame: .zero)
 

--- a/delighted/Classes/CES.swift
+++ b/delighted/Classes/CES.swift
@@ -39,7 +39,7 @@ class CESComponent: UIView, Component {
         var buttons = [Button]()
 
         for i in minNumber...maxNumber {
-            let button = Button(configuration: configuration, mode: .scale)
+            let button = Button(surveyConfiguration: configuration, mode: .scale)
             button.setTitle("\(i)", for: .normal)
             button.titleLabel?.font = configuration.font(ofSize: 16)
             button.isSelected = true

--- a/delighted/Classes/CSAT.swift
+++ b/delighted/Classes/CSAT.swift
@@ -38,7 +38,7 @@ class CSATComponent: UIView, Component {
         var buttons = [Button]()
 
         for i in minNumber...maxNumber {
-            let button = Button(configuration: configuration, mode: .scale)
+            let button = Button(surveyConfiguration: configuration, mode: .scale)
             button.setTitle("\(i)", for: .normal)
             button.titleLabel?.font = configuration.font(ofSize: 16)
             button.isSelected = true

--- a/delighted/Classes/OptionSelect.swift
+++ b/delighted/Classes/OptionSelect.swift
@@ -98,7 +98,7 @@ class OptionSelect: UIView {
     }
 
     private func makeButton(title: String) -> Button {
-        let button = Button(configuration: configuration, mode: .button)
+        let button = Button(surveyConfiguration: configuration, mode: .button)
         button.translatesAutoresizingMaskIntoConstraints = false
 
         button.setTitle(title, for: .normal)

--- a/delighted/Classes/PMF.swift
+++ b/delighted/Classes/PMF.swift
@@ -58,7 +58,7 @@ class PMFComponent: UIView, Component {
         let activeColor = theme.icon.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
 
-        let button = TintStateButton(configuration: configuration)
+        let button = TintStateButton(surveyConfiguration: configuration)
         button.setImage(image, for: .normal)
         button.setImage(image, for: .highlighted)
         button.setImage(image, for: .selected)

--- a/delighted/Classes/Smileys.swift
+++ b/delighted/Classes/Smileys.swift
@@ -58,7 +58,7 @@ class SmileysComponent: UIView, Component {
         let activeColor = theme.icon.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
 
-        let button = TintStateButton(configuration: configuration)
+        let button = TintStateButton(surveyConfiguration: configuration)
         button.setImage(image, for: .normal)
         button.setImage(image, for: .highlighted)
         button.setImage(image, for: .selected)

--- a/delighted/Classes/Stars.swift
+++ b/delighted/Classes/Stars.swift
@@ -54,7 +54,7 @@ class StarsComponent: UIView, Component {
         let activeColor = theme.stars.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
 
-        let button = TintStateButton(configuration: configuration)
+        let button = TintStateButton(surveyConfiguration: configuration)
         let selectedImage = Images.star.image
 
         switch theme.buttonStyle {

--- a/delighted/Classes/SurveyViewController.swift
+++ b/delighted/Classes/SurveyViewController.swift
@@ -210,7 +210,7 @@ public class SurveyViewController: UIViewController, DelightedPageViewController
     }()
 
     private lazy var submitButton: Button = {
-        let button = Button(configuration: configuration, mode: .primary)
+        let button = Button(surveyConfiguration: configuration, mode: .primary)
         button.translatesAutoresizingMaskIntoConstraints = false
 
         let buttonTitle = self.survey.template.additionalQuestions.isEmpty ? self.configuration.submitText : self.configuration.nextText

--- a/delighted/Classes/ThankYouViewController.swift
+++ b/delighted/Classes/ThankYouViewController.swift
@@ -80,7 +80,7 @@ public class ThankYouViewController: UIViewController, DelightedPageViewControll
     }()
 
     private lazy var linkButton: Button = {
-        let button = Button(configuration: configuration, mode: .primary)
+        let button = Button(surveyConfiguration: configuration, mode: .primary)
         button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 24, bottom: 8, right: 24)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(onLinkClick(sender:)), for: .touchUpInside)

--- a/delighted/Classes/Thumbs.swift
+++ b/delighted/Classes/Thumbs.swift
@@ -56,7 +56,7 @@ class ThumbsComponent: UIView, Component {
         let activeColor = theme.icon.activeBackgroundColor.color
         let darkerActiveColor = theme.stars.activeBackgroundColor.color.darker(by: 5) ?? activeColor
 
-        let button = TintStateButton(configuration: configuration)
+        let button = TintStateButton(surveyConfiguration: configuration)
         button.setImage(image, for: .normal)
         button.setImage(image, for: .highlighted)
         button.setImage(image, for: .selected)


### PR DESCRIPTION
The `Button` and `TintButton` classes should avoid using `configuration` so that
the SDK is compatible with iOS 15.

See [Button.Configuration](https://developer.apple.com/documentation/uikit/uibutton/configuration)