### PR TITLE
Deprecate Delighted iOS SDK - Delighted sunset June 30, 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.5.0 (2026-03-12)
+
+Deprecation:
+
+- Delighted is being sunset on June 30, 2026. This is the final release.
+  The package is now deprecated and will no longer be maintained.
+  See https://help.delighted.com/article/840-delighted-sunset-faq

--- a/Delighted.podspec
+++ b/Delighted.podspec
@@ -2,9 +2,9 @@
 
 Pod::Spec.new do |spec|
   spec.name                  = "Delighted"
-  spec.version               = "1.4.1"
-  spec.summary               = "Build native mobile app surveys for iOS using the Delighted SDK."
-  spec.description           = "Build your feedback program directly into your iOS apps using Delighted’s iOS SDK. Delighted’s seamless, user-focused survey experience, reimagined for iPhone."
+  spec.version               = "1.5.0"
+  spec.summary               = "[DEPRECATED] Build native mobile app surveys for iOS using the Delighted SDK."
+  spec.description           = "[DEPRECATED] Delighted is being sunset on June 30, 2026. This SDK is deprecated and will no longer be maintained. For more information, visit the Delighted Sunset FAQ: https://help.delighted.com/article/840-delighted-sunset-faq"
   spec.homepage              = "https://github.com/delighted/delighted-ios"
   spec.author                = { "Delighted" => "hello@delighted.com" }
   spec.license               = { file: "LICENSE" }
@@ -14,6 +14,7 @@ Pod::Spec.new do |spec|
   spec.swift_version         = "5.0"
   spec.ios.source_files      = "Sources/Delighted/Classes/*.swift"
   spec.resource_bundles      = { "Delighted_Delighted" => ["Sources/Delighted/Assets/*.xcassets"] }
+  spec.deprecated            = true
 
   spec.dependency "Starscream", "~> 4.0" # Support for Swift 5
 end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **DEPRECATION NOTICE:** Delighted is being sunset on June 30, 2026. This SDK is deprecated and will no longer be maintained or receive updates. For more information, visit the [Delighted Sunset FAQ](https://help.delighted.com/article/840-delighted-sunset-faq).
+
+---
+
 # Delighted iOS SDK
 
 The [Delighted](https://delighted.com) iOS SDK makes it quick and easy to gather

--- a/Sources/Delighted/Classes/Delighted.swift
+++ b/Sources/Delighted/Classes/Delighted.swift
@@ -35,6 +35,7 @@ import UIKit
     }
 
     @objc public static func initializeSDK() {
+        print("[Delighted] WARNING: Delighted is being sunset on June 30, 2026. This SDK is deprecated and will no longer be maintained or receive updates. For more information, visit the Delighted Sunset FAQ: https://help.delighted.com/article/840-delighted-sunset-faq")
         Logger.log(.info, "init")
         RequestCache.retryAll()
     }
@@ -48,6 +49,7 @@ import UIKit
         eligibilityOverrides: EligibilityOverrides? = nil,
         inViewController userViewController: UIViewController? = nil
     ) {
+        print("[Delighted] WARNING: Delighted is being sunset on June 30, 2026. This SDK is deprecated and will stop functioning after the sunset date. Visit: https://help.delighted.com/article/840-delighted-sunset-faq")
         survey(
             delightedID:
             delightedID,


### PR DESCRIPTION
## Summary

Delighted is being sunset on June 30, 2026. This is the final release of the Delighted iOS SDK (v1.5.0), marking it as deprecated.

For more information, visit the [Delighted Sunset FAQ](https://help.delighted.com/article/840-delighted-sunset-faq).

## Changes

- **`Sources/Delighted/Classes/Delighted.swift`**: Added `print()` deprecation warning in `initializeSDK()` and `survey()` methods. Developers will see the warning in their Xcode console.
- **`Delighted.podspec`**: Bumped version to `1.5.0`. Updated `summary` and `description` with deprecation notice. Added `spec.deprecated = true`.
- **`README.md`**: Added deprecation banner at the top.

## Distribution channels affected

- **CocoaPods**: Run `pod trunk deprecate Delighted` retroactively (separate from this PR). Also `spec.deprecated = true` in the podspec.
- **Swift Package Manager**: Users will see the deprecation in the README and in Xcode console output.
- **Carthage**: Same as SPM -- README is the primary signal.

## Pre-merge validation

| Check | Result |
|---|---|
| Podspec syntax valid | All fields valid, `spec.deprecated = true` present |
| `pod spec lint` | Expected fail (tag `1.5.0` doesn't exist on remote yet -- will pass after merge + tag) |
| Swift `print()` syntax | Valid |

## After merging

1. Tag the release as `1.5.0` (no `v` prefix -- matches existing convention)
2. Push the podspec: `RBENV_VERSION=3.3.1 pod trunk push Delighted.podspec --allow-warnings`
3. Run `RBENV_VERSION=3.3.1 pod trunk deprecate Delighted` (retroactive, all versions)
4. Archive this GitHub repository

<details>
<summary>Local validation steps</summary>

### 1. Verify podspec version

```bash
grep 'spec.version' Delighted.podspec
# Expected: spec.version = "1.5.0"
```

### 2. Verify deprecated flag

```bash
grep 'spec.deprecated' Delighted.podspec
# Expected: spec.deprecated = true
```

### 3. Lint podspec (after tag exists on remote)

```bash
RBENV_VERSION=3.3.1 pod spec lint Delighted.podspec --allow-warnings
```

Note: This will fail before the tag `1.5.0` is pushed to GitHub. Run after merge + tag.

</details>
